### PR TITLE
Removing single process type test from the essentials

### DIFF
--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -12,7 +12,7 @@
 - name: reasonable_startup_time 
   tags: microservice, dynamic, workload, cert, normal
 - name: single_process_type 
-  tags: microservice, dynamic, workload, essential, cert
+  tags: microservice, dynamic, workload, cert
   pass: 100
 - name: service_discovery
   tags: microservice, dynamic, workload, cert, bonus

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -12,7 +12,7 @@
 - name: reasonable_startup_time 
   tags: microservice, dynamic, workload, cert, normal
 - name: single_process_type 
-  tags: microservice, dynamic, workload, cert
+  tags: microservice, dynamic, workload, cert, bonus
   pass: 100
 - name: service_discovery
   tags: microservice, dynamic, workload, cert, bonus


### PR DESCRIPTION
## Description
Removing single process type test from the essentials

## Issues:
Refs: [#cnf-wg/issues/242](https://github.com/cncf/cnf-wg/issues/242)

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [X] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [?] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
