### PR TITLE
Bump crystal-ameba/ameba to 1.5.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.3.1
+    version: 1.5.0
 
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git

--- a/shard.yml
+++ b/shard.yml
@@ -76,6 +76,6 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.3.1
+    version: ~> 1.5.0
 
 license: MIT


### PR DESCRIPTION
# This is an automated update of a crystal dependency 

## WARNING: this requires an upgrade to Crystal. See comments below https://github.com/cnti-testcatalog/testsuite/pull/1811#issuecomment-1686048725


----

Bump crystal-ameba/ameba to 1.5.0

Fixes issue with shards install in macOS

Crystal version
```
Crystal 1.9.2 (2023-07-19)

LLVM: 15.0.7
Default target: x86_64-apple-macosx
```

Error message:
```
shards install
...
Building: ameba
Error target ameba failed to compile:
Showing last frame. Use --error-trace for full trace.

There was a problem expanding macro 'macro_5078464816'

Code in /usr/local/Cellar/crystal/1.9.2/share/crystal/src/yaml/serialization.cr:188:7

 188 | {% begin %}
       ^
Called macro defined in /usr/local/Cellar/crystal/1.9.2/share/crystal/src/yaml/serialization.cr:188:7

 188 | {% begin %}

Which expanded to:

 > 75 |
 > 76 |
 > 77 |                   __temp_735 =
                          ^
Error: type must be Ameba::Severity, not (Ameba::Severity | Nil)

make: *** [build] Error 1

```
## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.
