### PR TITLE
Fix output for elastic and db persistence tests

### DIFF
--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -18,7 +18,7 @@ describe "State" do
       $?.success?.should be_true
       response_s = `./cnf-testsuite -l info elastic_volumes verbose`
       LOGGING.info "Status:  #{response_s}"
-      (/PASSED: Elastic Volumes Used/ =~ response_s).should_not be_nil
+      (/PASSED: At least one of the volumes is elastic/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-elastic-volume/cnf-testsuite.yml`
       $?.success?.should be_true
@@ -54,7 +54,7 @@ describe "State" do
       # KubectlClient::Get.resource_wait_for_install("Pod", "mycluster-2")
       response_s = `LOG_LEVEL=info ./cnf-testsuite database_persistence`
       Log.info {"Status:  #{response_s}"}
-      (/PASSED: Elastic Volumes and Statefulsets Used/ =~ response_s).should_not be_nil
+      (/PASSED: At least one statefulset uses elastic volume/ =~ response_s).should_not be_nil
     ensure
       # Mysql.uninstall
        # KubectlClient::Delete.file("https://raw.githubusercontent.com/mysql/mysql-operator/trunk/samples/sample-cluster.yaml  --wait=false")
@@ -71,7 +71,7 @@ describe "State" do
       $?.success?.should be_true
       response_s = `./cnf-testsuite -l info elastic_volumes verbose`
       LOGGING.info "Status:  #{response_s}"
-      (/FAILED: Volumes used are not elastic volumes/ =~ response_s).should_not be_nil
+      (/FAILED: None of the volumes are elastic/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
       $?.success?.should be_true

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -412,9 +412,9 @@ task "elastic_volumes" do |_, args|
     if volumes_used == false
       resp = upsert_skipped_task(testsuite_task,"⏭️  ✨SKIPPED: No volumes used #{emoji_probe}", task_start_time)
     elsif elastic_volumes_used
-      resp = upsert_passed_task(testsuite_task,"✔️  ✨PASSED: Elastic Volumes Used #{emoji_probe}", task_start_time)
+      resp = upsert_passed_task(testsuite_task,"✔️  ✨PASSED: At least one of the volumes is elastic #{emoji_probe}", task_start_time)
     else
-      resp = upsert_failed_task(testsuite_task,"✔️  ✨FAILED: Volumes used are not elastic volumes #{emoji_probe}", task_start_time)
+      resp = upsert_failed_task(testsuite_task,"✖️  ✨FAILED: None of the volumes are elastic #{emoji_probe}", task_start_time)
     end
     resp
   end
@@ -472,13 +472,13 @@ task "database_persistence" do |_, args|
       end
       failed_emoji = "(ভ_ভ) ރ 💾"
       if elastic_statefulset
-        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: Elastic Volumes and Statefulsets Used #{emoji_probe}", task_start_time)
-      elsif elastic_volume_used 
-        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass3,"✔️  PASSED: Elastic Volumes Used #{emoji_probe}", task_start_time)
+        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: At least one statefulset uses elastic volume #{emoji_probe}", task_start_time)
       elsif statefulset_exists
         resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Neutral, "✖️  FAILED: Statefulset used without an elastic volume #{failed_emoji}", task_start_time)
+      elsif elastic_volume_used 
+        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass3,"✔️  PASSED: Statefulsets are not used, at least one volume is elastic #{emoji_probe}", task_start_time)
       else
-        resp = upsert_failed_task(testsuite_task,"✖️  FAILED: Elastic Volumes Not Used #{failed_emoji}", task_start_time)
+        resp = upsert_failed_task(testsuite_task,"✖️  FAILED: Statefulsets and elastic volumes are not used #{failed_emoji}", task_start_time)
       end
 
     else


### PR DESCRIPTION
Fixes #1201
Output of these tests should correctly represent what is being tested. With new messages - it is visible, that test logic is flawed and should be fixed (in another commit).
Change test messages of elastic_volumes and database_persistence Change expected messages in spec tests.

## Description
Change for test message in test and spec, changed order of statements in database_persistence so it would make sense. Was successfully built.
Changes in messages show what tests really do, proposed fixes and a bit of issue analysis is there:
https://github.com/cnti-testcatalog/testsuite/issues/1884

## Issues:
Refs: #1201

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
