### PR TITLE
Fix elastic_volumes and database_persistence logic

### DIFF
--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -54,7 +54,7 @@ describe "State" do
       # KubectlClient::Get.resource_wait_for_install("Pod", "mycluster-2")
       response_s = `LOG_LEVEL=info ./cnf-testsuite database_persistence`
       Log.info {"Status:  #{response_s}"}
-      (/PASSED: Elastic Volumes and Statefulsets Used/ =~ response_s).should_not be_nil
+      (/PASSED: CNF uses database with cloud-native persistence/ =~ response_s).should_not be_nil
     ensure
       # Mysql.uninstall
        # KubectlClient::Delete.file("https://raw.githubusercontent.com/mysql/mysql-operator/trunk/samples/sample-cluster.yaml  --wait=false")

--- a/src/tasks/utils/mysql.cr
+++ b/src/tasks/utils/mysql.cr
@@ -1,8 +1,9 @@
 require "cluster_tools"
 module Mysql
   MYSQL_PORT = "3306" 
+  MYSQL_IMAGES = ["mysql/mysql-server","bitnami/mysql"]
   def self.match()
-    ClusterTools.local_match_by_image_name(["mysql/mysql-server","bitnami/mysql"])
+    ClusterTools.local_match_by_image_name(MYSQL_IMAGES)
     # ClusterTools.local_match_by_image_name("bitnami/mysql")
   end
   def self.uninstall

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -387,7 +387,7 @@ task "elastic_volumes" do |_, args|
     Log.info {"cnf_config: #{config}"}
 
     emoji_probe="🧫"
-    elastic_volumes_used = false
+    all_volumes_elastic = true
     volumes_used = false
     task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource, containers, volumes, initialized|
       Log.for("elastic_volumes:test_resource").info { resource.inspect }
@@ -403,18 +403,18 @@ task "elastic_volumes" do |_, args|
       full_resource = KubectlClient::Get.resource(resource["kind"], resource["name"], namespace)
       elastic_result = WorkloadResource.elastic?(full_resource, volumes.as_a, namespace)
       Log.for("#{testsuite_task}:elastic_result").info {elastic_result}
-      if elastic_result
-        elastic_volumes_used = true
+      unless elastic_result
+        all_volumes_elastic = false
       end
     end
 
-    Log.for("elastic_volumes:result").info { "Volumes used: #{volumes_used}; Elastic?: #{elastic_volumes_used}" }
+    Log.for("elastic_volumes:result").info { "Volumes used: #{volumes_used}; Elastic?: #{all_volumes_elastic}" }
     if volumes_used == false
-      resp = upsert_skipped_task(testsuite_task,"⏭️  ✨SKIPPED: No volumes used #{emoji_probe}", task_start_time)
-    elsif elastic_volumes_used
-      resp = upsert_passed_task(testsuite_task,"✔️  ✨PASSED: Elastic Volumes Used #{emoji_probe}", task_start_time)
+      resp = upsert_skipped_task(testsuite_task,"⏭️  ✨SKIPPED: No volumes are used #{emoji_probe}", task_start_time)
+    elsif all_volumes_elastic
+      resp = upsert_passed_task(testsuite_task,"✔️  ✨PASSED: All used volumes are elastic #{emoji_probe}", task_start_time)
     else
-      resp = upsert_failed_task(testsuite_task,"✔️  ✨FAILED: Volumes used are not elastic volumes #{emoji_probe}", task_start_time)
+      resp = upsert_failed_task(testsuite_task,"✖️  ✨FAILED: Some of the used volumes are not elastic #{emoji_probe}", task_start_time)
     end
     resp
   end
@@ -440,11 +440,8 @@ task "database_persistence" do |_, args|
     # VERBOSE_LOGGING.info "database_persistence" if check_verbose(args)
     # todo K8s Database persistence test: if a mysql (or any popular database) image is installed:
     emoji_probe="🧫"
-    elastic_statefulset = false
-    elastic_volume_used = false
-    statefulset_exists = false
+    all_mysql_elastic_statefulset = true
     match = Mysql.match
-    # VERBOSE_LOGGING.info "hithere" if check_verbose(args)
     Log.info {"database_persistence mysql: #{match}"}
     if match && match[:found]
       default_namespace = "default"
@@ -452,37 +449,40 @@ task "database_persistence" do |_, args|
         default_namespace = config.cnf_config[:helm_install_namespace]
       end
       statefulset_exists = Helm.kind_exists?(args, config, "statefulset", default_namespace)
-      task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource, containers, volumes, initialized|
-        namespace = resource["namespace"] || default_namespace
-        Log.info {"database_persistence namespace: #{namespace}"}
-        Log.info {"database_persistence resource: #{resource}"}
-        Log.info {"database_persistence volumes: #{volumes}"}
-        # elastic_volume = Volume.elastic_by_volumes?(volumes)
-        full_resource = KubectlClient::Get.resource(resource["kind"], resource["name"], namespace)
-        elastic_volume = WorkloadResource.elastic?(full_resource, volumes.as_a, namespace)
-        Log.info {"database_persistence elastic_volume: #{elastic_volume}"}
-        if elastic_volume
-          elastic_volume_used = true
-        end
+      unless statefulset_exists
+        all_mysql_elastic_statefulset = false
+      else
+        task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource, containers, volumes, initialized|
 
-        if resource["kind"].downcase == "statefulset" && elastic_volume
-          elastic_statefulset = true
-        end
+          # Skip resources that do not have containers with mysql image
+          images = containers.as_a.map {|container| container["image"]}
+          next unless images.any? do |image| 
+            Mysql::MYSQL_IMAGES.any? do |mysql_image|
+              image.as_s.includes?(mysql_image) 
+            end
+          end
 
+          namespace = resource["namespace"] || default_namespace
+          Log.info {"database_persistence namespace: #{namespace}"}
+          Log.info {"database_persistence resource: #{resource}"}
+          Log.info {"database_persistence volumes: #{volumes}"}
+          full_resource = KubectlClient::Get.resource(resource["kind"], resource["name"], namespace)
+          elastic_volume = WorkloadResource.elastic?(full_resource, volumes.as_a, namespace)
+          Log.info {"database_persistence elastic_volume: #{elastic_volume}"}
+
+          unless resource["kind"].downcase == "statefulset" && elastic_volume
+            all_mysql_elastic_statefulset = false
+          end
+        end
       end
       failed_emoji = "(ভ_ভ) ރ 💾"
-      if elastic_statefulset
-        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: Elastic Volumes and Statefulsets Used #{emoji_probe}", task_start_time)
-      elsif elastic_volume_used 
-        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass3,"✔️  PASSED: Elastic Volumes Used #{emoji_probe}", task_start_time)
-      elsif statefulset_exists
-        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Neutral, "✖️  FAILED: Statefulset used without an elastic volume #{failed_emoji}", task_start_time)
+      if all_mysql_elastic_statefulset
+        resp = upsert_dynamic_task(testsuite_task,CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: CNF uses database with cloud-native persistence #{emoji_probe}", task_start_time)
       else
-        resp = upsert_failed_task(testsuite_task,"✖️  FAILED: Elastic Volumes Not Used #{failed_emoji}", task_start_time)
+        resp = upsert_failed_task(testsuite_task,"✖️  FAILED: CNF uses database without cloud-native persistence #{failed_emoji}", task_start_time)
       end
-
     else
-      resp = upsert_skipped_task(testsuite_task, "⏭️  SKIPPED: Mysql not installed #{emoji_probe}", task_start_time)
+      resp = upsert_skipped_task(testsuite_task, "⏭️  SKIPPED: CNF does not use database #{emoji_probe}", task_start_time)
     end
     resp
   end


### PR DESCRIPTION
elastic_volumes test should fail if any of the volumes is not elastic database_persistence test should test specifically resources with mysql images and pass if condition is true for all of them. This commit should fix that.
Fixes: #1884

## Description
Redesigned these tests according to the discussion in the #1884.
database_persistence is tested on bitnami/mysql helm chart (i don't have possibility to set up elastic volumes, so i've checked that it fails with elastic_volume condition and passes without it)

## Issues:
Refs: #1884

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
