### PR TITLE
[bug/1900] Update repo url used with GithubReleaseManager

### DIFF
--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -82,7 +82,7 @@ task "upsert_release" do |_, args|
   # LOGGING.info "upserting release on: #{ReleaseManager::VERSION}"
   LOGGING.info "upserting release on: #{ReleaseManager::VERSION}"
 
-  ghrm = ReleaseManager::GithubReleaseManager.new("cncf/cnf-testsuite")
+  ghrm = ReleaseManager::GithubReleaseManager.new("cnti-testcatalog/testsuite")
 
   release, asset = ghrm.upsert_release(version=ReleaseManager::VERSION)
   if release


### PR DESCRIPTION
## Description
The repo url used with `ReleaseManager::GitHubReleaseManager` needs to be updated for the `Publish Release` GitHub Actions step to work as expected. This is currently failing in the `main` branch builds.

## Issues:
Refs: #1900

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
