### PR TITLE
Removal of allowlist from priviledged tests

### DIFF
--- a/example-cnfs/coredns/cnf-testsuite.yml
+++ b/example-cnfs/coredns/cnf-testsuite.yml
@@ -1,5 +1,4 @@
 ---
-allowlist_helm_chart_container_names: [] # [LIST_OF_CONTAINERS_ALLOWED_TO_RUN_PRIVLIDGED]
 helm_chart: stable/coredns # PUBLISHED_CNFS_HELM_CHART_REPO/NAME ; or
 helm_repository: # CONFIGURATION OF HELM REPO - ONLY NEEDED WHEN USING helm_chart
   name: stable # HELM_CHART_REPOSITORY_NAME

--- a/example-cnfs/envoy/cnf-testsuite.yml
+++ b/example-cnfs/envoy/cnf-testsuite.yml
@@ -5,5 +5,4 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]
 helm_install_namespace: cnfspace

--- a/example-cnfs/nsm/cnf-testsuite.yml
+++ b/example-cnfs/nsm/cnf-testsuite.yml
@@ -5,5 +5,4 @@ service_name: nsm-admission-webhook-svc
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []
 helm_install_namespace: cnfspace

--- a/sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml
@@ -6,4 +6,3 @@ service_name:
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
@@ -7,4 +7,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 rolling_update_test_tag: 1.6.7
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/k8s-non-helm-no-image-policy/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-non-helm-no-image-policy/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx-webapp
 helm_repository:
   name:
   repo_url:
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/k8s-non-helm/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-non-helm/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx-webapp
 helm_repository:
   name:
   repo_url:
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml
@@ -9,4 +9,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 rolling_update_test_tag: 1.6.7
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/multi_helm_directories/cnf-testsuite.yml
+++ b/sample-cnfs/multi_helm_directories/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-immutable-configmap/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-immutable-configmap/cnf-testsuite.yml
@@ -13,4 +13,3 @@ container_names:
     rolling_downgrade_test_tag: latest
     rolling_version_change_test_tag: latest
     rollback_from_tag: latest
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: wordpress 
 helm_install_namespace: wordpress
 release_name: test 
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-mutable-configmap/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-mutable-configmap/cnf-testsuite.yml
@@ -13,4 +13,3 @@ container_names:
     rolling_downgrade_test_tag: latest
     rolling_version_change_test_tag: latest
     rollback_from_tag: latest
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-non-root-user/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-non-root-user/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-reasonable-image-size/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-reasonable-image-size/cnf-testsuite.yml
@@ -3,4 +3,3 @@ helm_chart: oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest
 helm_install_namespace: "envoy-gateway-system"
 release_name: envoy 
 service_name: envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]

--- a/sample-cnfs/sample-alpha-apis/cnf-testsuite.yml
+++ b/sample-cnfs/sample-alpha-apis/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-appliciation-credentials/cnf-testsuite.yml
+++ b/sample-cnfs/sample-appliciation-credentials/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-bad-helm-deploy-repo/cnf-testsuite.yml
+++ b/sample-cnfs/sample-bad-helm-deploy-repo/cnf-testsuite.yml
@@ -5,4 +5,3 @@ service_name: coredns-coredns
 helm_repository:
   name: stable
   repo_url: https://bad-helm-repo.googleapis.com
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-bad-helm-repo/cnf-testsuite.yml
+++ b/sample-cnfs/sample-bad-helm-repo/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: badrepo
   repo_url: https://bad-helm-repo.googleapis.com
 helm_chart: badrepo/coredns
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-bad-zombie/cnf-testsuite.yml
+++ b/sample-cnfs/sample-bad-zombie/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: bad-helm-coredns-coredns
 service_name: bad-helm-coredns-coredns
-allowlist_helm_chart_container_names: [nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf-bad-chart/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf-bad-chart/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/corsdsdsdedns
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf-source/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf-source/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 release_name: coredns
 service_name: coredns-coredns 
 helm_chart: stable/coredns
-allowlist_helm_chart_container_names: [nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf2/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf2/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
 helm_install_namespace: cnfspace2
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf3/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf3/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
 helm_install_namespace: cnfspace3
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf4/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf4/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
 helm_install_namespace: cnfspace4
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-elastic-volume/cnf-testsuite.yml
+++ b/sample-cnfs/sample-elastic-volume/cnf-testsuite.yml
@@ -4,4 +4,3 @@ helm_repository:
   name: prometheus-community 
   repo_url: https://prometheus-community.github.io/helm-charts
 helm_chart: prometheus-community/prometheus
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-fluentbit/cnf-testsuite.yml
+++ b/sample-cnfs/sample-fluentbit/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx-fluentbit
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-fragile-state/cnf-testsuite.yml
+++ b/sample-cnfs/sample-fragile-state/cnf-testsuite.yml
@@ -3,4 +3,3 @@ helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
 rolling_update_test_tag: 1.6.7
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-generic-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-generic-cnf/cnf-testsuite.yml
@@ -5,9 +5,3 @@ helm_repository:
   name: stable
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
-allowlist_helm_chart_container_names:
-- nginx
-- coredns
-- calico-node
-- kube-proxy
-- nginx-proxy

--- a/sample-cnfs/sample-hostpath/cnf-testsuite.yml
+++ b/sample-cnfs/sample-hostpath/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-immutable-fs/cnf-testsuite.yml
+++ b/sample-cnfs/sample-immutable-fs/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-init-systems/cnf-testsuite.yml
+++ b/sample-cnfs/sample-init-systems/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-insecure-capabilities/cnf-testsuite.yml
+++ b/sample-cnfs/sample-insecure-capabilities/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-large-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-large-cnf/cnf-testsuite.yml
@@ -5,4 +5,3 @@ service_name: coredns-coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-local-storage/cnf-testsuite.yml
+++ b/sample-cnfs/sample-local-storage/cnf-testsuite.yml
@@ -3,4 +3,3 @@ helm_directory: chart
 helm_values: 
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-multi-db-connections-exempt/cnf-testsuite.yml
+++ b/sample-cnfs/sample-multi-db-connections-exempt/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: wordpress 
 helm_values: "--set mariadb.primary.persistence.enabled=false --set persistence.enabled=false"
 release_name: test 
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-multi-db-connections-fail/cnf-testsuite.yml
+++ b/sample-cnfs/sample-multi-db-connections-fail/cnf-testsuite.yml
@@ -1,4 +1,3 @@
 ---
 helm_directory: wordpress 
 release_name: test --set mariadb.primary.persistence.enabled=false --set persistence.enabled=false 
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name:
   repo_url:
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-ndn-privileged/cnf-testsuite.yml
+++ b/sample-cnfs/sample-ndn-privileged/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-nonroot-containers/cnf-testsuite.yml
+++ b/sample-cnfs/sample-nonroot-containers/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-nonroot/cnf-testsuite.yml
+++ b/sample-cnfs/sample-nonroot/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-openmetrics/cnf-testsuite.yml
+++ b/sample-cnfs/sample-openmetrics/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: openmetrics-compliant
 helm_repository:
   name:
   repo_url:
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
+++ b/sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml
+++ b/sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-service-accounts/cnf-testsuite.yml
+++ b/sample-cnfs/sample-service-accounts/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml
@@ -6,7 +6,6 @@ helm_repository:
   name: bitnami 
   repo_url: https://charts.bitnami.com/bitnami 
 helm_chart: bitnami/wordpress 
-allowlist_helm_chart_container_names: [nginx, coredns, calico-node, kube-proxy, nginx-proxy]
 
 # The below configuration for the rolling tests
 # refer to container image versions that are

--- a/sample-cnfs/sample-statefulset-nginx/cnf-testsuite.yml
+++ b/sample-cnfs/sample-statefulset-nginx/cnf-testsuite.yml
@@ -4,7 +4,6 @@ manifest_directory: manifests
 helm_repository:
   name:
   repo_url:
-allowlist_helm_chart_container_names: []
 
 # The below configuration for the rolling tests
 # refer to container image versions that are

--- a/sample-cnfs/sample-statefulsets/cnf-testsuite.yml
+++ b/sample-cnfs/sample-statefulsets/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-tracing/cnf-testsuite.yml
+++ b/sample-cnfs/sample-tracing/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: test
 helm_repository:
   name: jaegertracing 
   repo_url: https://jaegertracing.github.io/helm-charts
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_bad_signal_handling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_bad_signal_handling/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: envoy 
 service_name: envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]

--- a/sample-cnfs/sample_container_sock_mount/cnf-testsuite.yml
+++ b/sample-cnfs/sample_container_sock_mount/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml
@@ -3,4 +3,3 @@ helm_directory: chart
 helm_install_namespace: cnfspace
 release_name: bad-liveness
 service_name: bad-liveness-coredns 
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_chart_directory/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_chart_directory/cnf-testsuite.yml
@@ -1,4 +1,3 @@
 ---
 helm_directory: chart
 release_name: coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_default_namespace/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_default_namespace/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_install_namespace: default
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_hardcoded_ips/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_hardcoded_ips/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_protected/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_protected/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns --set imageCredentials.registry=https://index.docker.io/v1/ --set imageCredentials.username=$PROTECTED_DOCKERHUB_USERNAME --set imageCredentials.password=$PROTECTED_DOCKERHUB_PASSWORD --set imageCredentials.email=$PROTECTED_DOCKERHUB_EMAIL --set image.repository=$PROTECTED_IMAGE_REPO
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_values/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_values/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_values: "--set image.tag=1.6.9"
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml
+++ b/sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: envoy 
 service_name: envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]

--- a/sample-cnfs/sample_external_ips/cnf-testsuite.yml
+++ b/sample-cnfs/sample_external_ips/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_good_signal_handling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_good_signal_handling/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: envoy 
 service_name: envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]

--- a/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
+++ b/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
@@ -7,4 +7,3 @@ helm_repository:
 helm_chart: jenkins/jenkins
 helm_install_namespace: cnfspace
 helm_values: "--set controller.sidecars.configAutoReload.enabled=false"
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample_good_zombie_handling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_good_zombie_handling/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: envoy 
 service_name: envoy
-allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]

--- a/sample-cnfs/sample_hostport/cnf-testsuite.yml
+++ b/sample-cnfs/sample_hostport/cnf-testsuite.yml
@@ -5,4 +5,3 @@ git_clone_url:
 install_script: chart
 release_name: unifi
 service_name: unifi-controller 
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_immutable_configmap_all/cnf-testsuite.yml
+++ b/sample-cnfs/sample_immutable_configmap_all/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_immutable_configmap_all_plus_env/cnf-testsuite.yml
+++ b/sample-cnfs/sample_immutable_configmap_all_plus_env/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_immutable_configmap_all_plus_env_but_fail/cnf-testsuite.yml
+++ b/sample-cnfs/sample_immutable_configmap_all_plus_env_but_fail/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_immutable_configmap_some/cnf-testsuite.yml
+++ b/sample-cnfs/sample_immutable_configmap_some/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_latest_tag/cnf-testsuite.yml
+++ b/sample-cnfs/sample_latest_tag/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_local_registry/cnf-testsuite.yml
+++ b/sample-cnfs/sample_local_registry/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_local_registry_org_image/cnf-testsuite.yml
+++ b/sample-cnfs/sample_local_registry_org_image/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_local_registry_rolling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_local_registry_rolling/cnf-testsuite.yml
@@ -2,7 +2,6 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []
 container_names: 
   - name: coredns 
     rolling_update_test_tag: "1.8.0"

--- a/sample-cnfs/sample_network_loss/cnf-testsuite.yml
+++ b/sample-cnfs/sample_network_loss/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: coredns
 service_name: coredns-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_no_logs/cnf-testsuite.yml
+++ b/sample-cnfs/sample_no_logs/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: python-http-server
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_nodeport/cnf-testsuite.yml
+++ b/sample-cnfs/sample_nodeport/cnf-testsuite.yml
@@ -4,5 +4,4 @@ helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: chart
 release_name: unifi
-service_name: unifi-controller 
-allowlist_helm_chart_container_names: []
+service_name: unifi-controller

--- a/sample-cnfs/sample_nonroot/cnf-testsuite.yml
+++ b/sample-cnfs/sample_nonroot/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_open5gs/cnf-testsuite.yml
+++ b/sample-cnfs/sample_open5gs/cnf-testsuite.yml
@@ -1,7 +1,6 @@
 ---
 helm_directory: open5gs
 release_name: open5gs
-allowlist_helm_chart_container_names: []
 #optional 5gcore tag
 amf_label: app.kubernetes.io/name=amf
 smf_label: app.kubernetes.io/name=smf

--- a/sample-cnfs/sample_open5gs_no_auth/cnf-testsuite.yml
+++ b/sample-cnfs/sample_open5gs_no_auth/cnf-testsuite.yml
@@ -1,7 +1,6 @@
 ---
 helm_directory: open5gs
 release_name: open5gs
-allowlist_helm_chart_container_names: []
 #optional 5gcore tag
 amf_label: app.kubernetes.io/name=amf
 amf_service_name: open5gs-amf-ngap

--- a/sample-cnfs/sample_operator/cnf-testsuite.yml
+++ b/sample-cnfs/sample_operator/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_privileged_cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample_privileged_cnf/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: chart
 release_name: privileged-coredns
 service_name: privileged-coredns
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_rolling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_rolling/cnf-testsuite.yml
@@ -5,7 +5,6 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_install_namespace: cnfspace
-allowlist_helm_chart_container_names: []
 container_names: 
   - name: coredns 
     rolling_update_test_tag: "1.8.0"

--- a/sample-cnfs/sample_rolling_invalid_version/cnf-testsuite.yml
+++ b/sample-cnfs/sample_rolling_invalid_version/cnf-testsuite.yml
@@ -5,7 +5,6 @@ service_name: coredns-coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names: []
 container_names: 
   - name: coredns 
     rolling_update_test_tag: "this_is_not_a_valid_version"

--- a/sample-cnfs/sample_secret_env/cnf-testsuite.yml
+++ b/sample-cnfs/sample_secret_env/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: postgresql
 release_name: postgresql
 service_name: postgresql
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_secret_env_no_ref/cnf-testsuite.yml
+++ b/sample-cnfs/sample_secret_env_no_ref/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: postgresql
 release_name: postgresql
 service_name: postgresql
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_secret_volume/cnf-testsuite.yml
+++ b/sample-cnfs/sample_secret_volume/cnf-testsuite.yml
@@ -5,4 +5,3 @@ git_clone_url:
 install_script: chart
 release_name: postgresql
 service_name: postgresql
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml
+++ b/sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml
@@ -1,7 +1,6 @@
 ---
 helm_directory: open5gs
 release_name: open5gs
-allowlist_helm_chart_container_names: []
 #optional 5gcore tag
 core: app.kubernetes.io/name=amf
 amf_service_name: open5gs-amf-ngap

--- a/sample-cnfs/sample_sysctls/cnf-testsuite.yml
+++ b/sample-cnfs/sample_sysctls/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_unmounted_secret_volume/cnf-testsuite.yml
+++ b/sample-cnfs/sample_unmounted_secret_volume/cnf-testsuite.yml
@@ -5,4 +5,3 @@ git_clone_url:
 install_script: chart
 release_name: postgresql
 service_name: postgresql
-allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_valid_selinux_options/cnf-testsuite.yml
+++ b/sample-cnfs/sample_valid_selinux_options/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: nginx
 helm_repository:
   name: 
   repo_url:
-allowlist_helm_chart_container_names: []

--- a/spec/fixtures/cnf-testsuite-not-exclusive.yml
+++ b/spec/fixtures/cnf-testsuite-not-exclusive.yml
@@ -5,10 +5,3 @@ release_name: coredns
 helm_repository:
   name: stable
   repo_url: https://cncf.gitlab.io/stable
-allowlist_helm_chart_container_names:
-- node-cache
-- nginx
-- coredns
-- calico-node
-- kube-proxy
-- nginx-proxy

--- a/spec/fixtures/cnf-testsuite-unmapped-keys-and-subkeys.yml
+++ b/spec/fixtures/cnf-testsuite-unmapped-keys-and-subkeys.yml
@@ -6,5 +6,4 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
   test_on_helm_repo:
 helm_chart: stable/coredns
-allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]
 test_at_root:

--- a/spec/fixtures/cnf-testsuite.yml
+++ b/spec/fixtures/cnf-testsuite.yml
@@ -4,10 +4,3 @@ helm_repository:
   name: stable
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
-allowlist_helm_chart_container_names:
-- node-cache
-- nginx
-- coredns
-- calico-node
-- kube-proxy
-- nginx-proxy

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -6,6 +6,7 @@ require "../../src/tasks/helmenv_setup.cr"
 require "kubectl_client"
 require "file_utils"
 require "sam"
+require "json"
 
 describe "Utils" do
   before_all do
@@ -89,9 +90,10 @@ describe "Utils" do
       resource_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
         privileged_list = KubectlClient::Get.privileged_containers
-        white_list_containers = ((PRIVILEGED_WHITELIST_CONTAINERS + white_list_container_names) - [container])
+        resource_containers = KubectlClient::Get.resource_containers(resource["kind"],resource["name"],resource["namespace"])
+        resource_containers_list = (JSON.parse(resource_containers.to_json).as_a).map { |element| element["name"] }
         # Only check the containers that are in the deployed helm chart or manifest
-        (privileged_list & ([container.as_h["name"].as_s] - white_list_containers)).each do |x|
+        (privileged_list & (resource_containers_list - white_list_container_names)).each do |x|
           violation_list << x
         end
         if violation_list.size > 0
@@ -161,9 +163,10 @@ describe "Utils" do
       resource_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
         privileged_list = KubectlClient::Get.privileged_containers
-        white_list_containers = ((PRIVILEGED_WHITELIST_CONTAINERS + white_list_container_names) - [container])
+        resource_containers = KubectlClient::Get.resource_containers(resource["kind"],resource["name"],resource["namespace"])
+        resource_containers_list = (JSON.parse(resource_containers.to_json).as_a).map { |element| element["name"] }
         # Only check the containers that are in the deployed helm chart or manifest
-        (privileged_list & ([container.as_h["name"].as_s] - white_list_containers)).each do |x|
+        (privileged_list & (resource_containers_list - white_list_container_names)).each do |x|
           violation_list << x
         end
         if violation_list.size > 0

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -12,7 +12,6 @@ ERROR = "error"
 # todo move to helm module
 # CHART_YAML = "Chart.yaml"
 DEFAULT_POINTSFILENAME = "points_v1.yml"
-PRIVILEGED_WHITELIST_CONTAINERS = ["chaos-daemon", "cluster-tools"]
 SONOBUOY_K8S_VERSION = "0.56.14"
 KUBESCAPE_VERSION = "3.0.8"
 KUBESCAPE_FRAMEWORK_VERSION = "1.0.316"


### PR DESCRIPTION
## Description
This change updates priviledged test to consider
only containers from CNF under test. As a result of this change, the 'allowlist_helm_chart_container_names' parameter in the cnf-testsuite.yml configuration file is no longer needed.
Therefore this patch also removes this parameter from the configuration, as well as from all samples and examples.

## Issues:
Refs: #1906

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
