### PR TITLE
Adding local helm binary for spec tests

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -2,6 +2,7 @@
 require "../spec_helper"
 require "colorize"
 require "../../src/tasks/utils/utils.cr"
+require "../../src/tasks/helmenv_setup.cr"
 require "kubectl_client"
 require "file_utils"
 require "sam"


### PR DESCRIPTION
Ref #1909

## Description
[BUG] Spec tests are unable to find local Helm installation. #1909


## Issues:
Refs: #1909 

## How has this been tested:
- by executing spec tests

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
