### PR TITLE
Set helm_install_namespace in all example cnf-testsuite.yml

### DIFF
--- a/example-cnfs/coredns/cnf-testsuite.yml
+++ b/example-cnfs/coredns/cnf-testsuite.yml
@@ -7,3 +7,4 @@ helm_repository: # CONFIGURATION OF HELM REPO - ONLY NEEDED WHEN USING helm_char
 #helm_directory: coredns # PATH_TO_CNFS_HELM_CHART ; or
 #manifest_directory: coredns # PATH_TO_DIRECTORY_OF_CNFS_MANIFEST_FILES ; or
 release_name: coredns # DESIRED_HELM_RELEASE_NAME
+helm_install_namespace: cnfspace

--- a/example-cnfs/coredns/cnf-testsuite.yml
+++ b/example-cnfs/coredns/cnf-testsuite.yml
@@ -8,3 +8,9 @@ helm_repository: # CONFIGURATION OF HELM REPO - ONLY NEEDED WHEN USING helm_char
 #manifest_directory: coredns # PATH_TO_DIRECTORY_OF_CNFS_MANIFEST_FILES ; or
 release_name: coredns # DESIRED_HELM_RELEASE_NAME
 helm_install_namespace: cnfspace
+container_names:
+  - name: coredns
+    rolling_update_test_tag: "1.8.0"
+    rolling_downgrade_test_tag: 1.6.7
+    rolling_version_change_test_tag: 1.8.0
+    rollback_from_tag: 1.8.0

--- a/example-cnfs/envoy/cnf-testsuite.yml
+++ b/example-cnfs/envoy/cnf-testsuite.yml
@@ -6,3 +6,4 @@ helm_repository:
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/envoy
 allowlist_helm_chart_container_names: [nginx, envoy, calico-node, kube-proxy, nginx-proxy, node-cache]
+helm_install_namespace: cnfspace

--- a/example-cnfs/ip-forwarder/cnf-testsuite.yml
+++ b/example-cnfs/ip-forwarder/cnf-testsuite.yml
@@ -4,3 +4,4 @@ release_name: vpp
 service_name: ""
 rolling_update_test_tag: latest
 allowlist_helm_chart_container_names: [nginx, calico-node, kube-proxy, nginx-proxy, node-cache, kube-multus]
+helm_install_namespace: cnfspace

--- a/example-cnfs/nsm/cnf-testsuite.yml
+++ b/example-cnfs/nsm/cnf-testsuite.yml
@@ -6,3 +6,4 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 allowlist_helm_chart_container_names: []
+helm_install_namespace: cnfspace

--- a/example-cnfs/pantheon-nsm-nat/cnf-testsuite.yml
+++ b/example-cnfs/pantheon-nsm-nat/cnf-testsuite.yml
@@ -3,3 +3,4 @@ helm_directory: nat-cnf
 release_name: cnf-nat 
 service_name: 
 allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy, kube-multus]
+helm_install_namespace: cnfspace

--- a/example-cnfs/vpp-3c2n-csp-use-case/cnf-testsuite.yml
+++ b/example-cnfs/vpp-3c2n-csp-use-case/cnf-testsuite.yml
@@ -2,3 +2,4 @@
 helm_directory: csp
 release_name: ip-forwarder-csp
 allowlist_helm_chart_container_names: [nginx, calico-node, kube-proxy, nginx-proxy, node-cache]
+helm_install_namespace: cnfspace


### PR DESCRIPTION
## Description

example-cnfs/coredns fails passing default_namespace by default and fails in gates too [1].

It forces now deployment coredns-coredns to be in cnfspace.
Please note it sets helm_install_namespace in all example cnf-testsuite.yml when missing.

[1] https://github.com/cnti-testcatalog/testsuite/actions/runs/8564278589/job/23493678803#step:11:1170

## Issues:
Refs: #1952

## How has this been tested:
 - [X] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update