### PR TITLE
fix: add condition in method ensure_kubeconfig!

### DIFF
--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -10,6 +10,7 @@ task "setup", ["version", "offline", "helm_local_install", "prereqs", "create_na
 end
 
 task "create_namespace" do |_, args|
+  ensure_kubeconfig!
   if KubectlClient::Create.namespace(TESTSUITE_NAMESPACE)
     stdout_success "Created #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
   else

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -43,13 +43,16 @@ def ensure_kubeconfig!
   kubeconfig_path = File.join(ENV["HOME"], ".kube", "config")
   
   if ENV.has_key?("KUBECONFIG") && File.exists?(ENV["KUBECONFIG"])
-    puts "KUBECONFIG is already set.".colorize(:green)
+    stdout_success "KUBECONFIG is already set."
   elsif File.exists?(kubeconfig_path)
     ENV["KUBECONFIG"] = kubeconfig_path
-    puts "KUBECONFIG is set as #{ENV["KUBECONFIG"]}.".colorize(:green)
+    stdout_success "KUBECONFIG is set as #{ENV["KUBECONFIG"]}."
+  elsif !ENV.has_key?("KUBECONFIG")
+    stdout_failure "KUBECONFIG is not set and default path #{kubeconfig_path} does not exist. Please set KUBECONFIG to an existing config file, i.e. 'export KUBECONFIG=path-to-your-kubeconfig'"
+    exit 1
   else
-    puts "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'".colorize(:red)
-    raise "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'"
+    stdout_failure "KUBECONFIG is set to #{ENV["KUBECONFIG"]} path and it does not exist. Please set KUBECONFIG to an existing config file, i.e. 'export KUBECONFIG=path-to-your-kubeconfig'"
+    exit 1
   end
 
 end


### PR DESCRIPTION
## Description
 - add one more elsif condition in case variable KUBECONFIG is not set (empty)
  - change error messages

## Issues:
Refs: #985 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
