### PR TITLE
chmod a+x cnf-testsuite in curl_install.sh

### DIFF
--- a/curl_install.sh
+++ b/curl_install.sh
@@ -31,6 +31,7 @@ LATEST_RELEASE=$(get_latest_release cnti-testcatalog/testsuite)
 mkdir -p ~/.cnf-testsuite
 curl --silent -L https://github.com/cnti-testcatalog/testsuite/releases/download/$LATEST_RELEASE/cnf-testsuite-$LATEST_RELEASE.tar.gz -o ~/.cnf-testsuite/cnf-testsuite.tar.gz
 tar -C ~/.cnf-testsuite -xf ~/.cnf-testsuite/cnf-testsuite.tar.gz
+chmod a+x ~/.cnf-testsuite/cnf-testsuite
 rm ~/.cnf-testsuite/cnf-testsuite.tar.gz
 
 if [ -z ${SHELL_UNSUPPORTED+x} ]; then


### PR DESCRIPTION
## Description

cnf-testsuite isn't executable in the archive which breaks [Installation and Usage](https://github.com/cnti-testcatalog/testsuite?tab=readme-ov-file#installation-and-usage)
curl_install.sh must also chmod the binary.

## Types of changes:
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
