### PR TITLE
Prevent microservice tests from passing on errors

### DIFF
--- a/src/tasks/utils/init_systems.cr
+++ b/src/tasks/utils/init_systems.cr
@@ -34,8 +34,9 @@ module InitSystems
     return false
   end
 
-  def self.scan(pod : JSON::Any) : Array(InitSystemInfo)
+  def self.scan(pod : JSON::Any) : Array(InitSystemInfo) | Nil
     failed_resources = [] of InitSystemInfo
+    error_occurred = false
 
     nodes = KubectlClient::Get.nodes_by_pod(pod)
     pod_name = pod.dig("metadata", "name")
@@ -69,10 +70,12 @@ module InitSystems
         if !InitSystems.is_specialized_init_system?(container_init_cmd)
           failed_resources << init_info
         end
+      else
+        error_occurred = true
       end
     end
 
-    return failed_resources
+    return error_occurred ? nil : failed_resources
   end
 
   def self.get_container_init_cmd(node, container_id) : String?


### PR DESCRIPTION
## Description
This updates the behaviour so the test will not pass when there is an environment or external error causing the test to not be able to do a complete validation as intended. (eg. the containers could not be inspected because of an external unrelated issue).

The error is reported and the test will not pass.

## Issues:
Refs: #1959

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
