### PR TITLE
fix immutable configmaps typo

### DIFF
--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -530,7 +530,7 @@ task "immutable_configmap" do |t, args|
     immutable_configmap_supported = true
     immutable_configmap_enabled = true
 
-    # if the reapply with a change succedes immmutable configmaps is NOT enabled
+    # if the reapply with a change succedes immutable configmaps is NOT enabled
     # if KubectlClient::Apply.file(test_config_map_filename) == 0
     apply_result = KubectlClient::Apply.file(test_config_map_filename)
 
@@ -541,9 +541,9 @@ task "immutable_configmap" do |t, args|
       Log.for(t.name).info { "kubectl apply on immutable configmap succeeded for: #{test_config_map_filename}" }
       k8s_ver = KubectlClient.server_version
       if version_less_than(k8s_ver, "1.19.0")
-        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Skipped, "immmutable configmaps are not supported in this k8s cluster")
+        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Skipped, "immutable configmaps are not supported in this k8s cluster")
       else
-        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Failed, "immmutable configmaps are not enabled in this k8s cluster")
+        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Failed, "immutable configmaps are not enabled in this k8s cluster")
       end
     else
 


### PR DESCRIPTION
## Description
Minor change to fix immutable configmaps typo

## Issues:
Refs: #na

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
