### PR TITLE
Remove pod_dns_error from certification

### DIFF
--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -115,9 +115,7 @@
   tags: [resilience, dynamic, workload, cert, normal]
 - name: pod_dns_error
   emoji: "🗡️💀♻"
-  tags: [resilience, dynamic, workload, essential, cert]
-  pass: 100
-  fail: 0
+  tags: [resilience, dynamic, workload]
 #- name: external_retry 
 #  tags: scalability, dynamic, workload
 

--- a/src/tasks/cert/cert_resilience.cr
+++ b/src/tasks/cert/cert_resilience.cr
@@ -13,7 +13,6 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
    "pod_delete",
    "pod_memory_hog",
    "pod_io_stress",
-   "pod_dns_error",
    "pod_network_duplication",
    "liveness",
    "readiness"


### PR DESCRIPTION
pod_dns_error requires docker k8s runtime.
This is not aligned with certification environment requirements, thus removing the test from certification. Refs:#1977

## Description
(name of issue/change)

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
