### PR TITLE
Check if cluster-tools are installed untill timeout

### DIFF
--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -32,7 +32,11 @@ task "cnf_setup", ["helm_local_install", "create_namespace"] do |_, args|
     puts "cnf setup airgapped mode complete".colorize(:green)
   else
     Log.info { "Installing ClusterTools"}
-    ClusterTools.install
+    if ClusterTools.install
+      puts "ClusterTools installed".colorize(:green)
+    else
+      puts "The ClusterTools installation timed out. Please check the status of the cluster-tools pods.".colorize(:red)
+    end
     puts "cnf setup online mode".colorize(:green)
     CNFManager.sample_setup(cli_hash)
     puts "cnf setup online mode complete".colorize(:green)


### PR DESCRIPTION
## Description
This change adds checking if cluster-tools successfully installed during the cnf_setup task. It simply checks return value of ClusterTools.install.

## Issues:
Refs: #1975 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
