### PR TITLE
improvement: check if cluster is up and running

### DIFF
--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -55,7 +55,14 @@ def ensure_kubeconfig!
     stdout_failure "KUBECONFIG is set to #{ENV["KUBECONFIG"]} path and it does not exist. Please set KUBECONFIG to an existing config file, i.e. 'export KUBECONFIG=path-to-your-kubeconfig'"
     exit 1
   end
-
+  
+  # Check if cluster is up and running with assigned KUBECONFIG variable 
+  cmd = "kubectl get nodes --kubeconfig=#{ENV["KUBECONFIG"]}"
+  exit_code = KubectlClient::ShellCmd.run(cmd, "", false)[:status].exit_status
+  if exit_code != 0
+    stdout_failure "Cluster liveness check failed: '#{cmd}' returned exit code #{exit_code}. Check the cluster and/or KUBECONFIG environment variable."
+    exit 1
+  end
 end
 
 def log_formatter


### PR DESCRIPTION
## Description
Add condition in ensure_kubeconfig! method to check the cluster's health. 

## Issues:
Refs: #1968

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
