### PR TITLE
remove cni_compatible from cert tests

### DIFF
--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -38,7 +38,7 @@
   pass: 100
 - name: cni_compatible
   emoji: "🔓🔑"
-  tags: [compatibility, dynamic, workload, cert, normal]
+  tags: [compatibility, dynamic, workload]
 # - name: cni_spec 
 #  tags: compatibility, dynamic
 #- name: api_snoop_alpha 

--- a/src/tasks/cert/cert_compatibility.cr
+++ b/src/tasks/cert/cert_compatibility.cr
@@ -6,7 +6,7 @@ require "totem"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if CNFs support horizontal scaling (across multiple machines) and vertical scaling (between sizes of machines) by using the native K8s kubectl"
-task "cert_compatibility", ["cert_compatibility_title", "helm_chart_valid", "helm_chart_published", "helm_deploy", "cni_compatible", "increase_decrease_capacity", "rollback"] do |_, args|
+task "cert_compatibility", ["cert_compatibility_title", "helm_chart_valid", "helm_chart_published", "helm_deploy", "increase_decrease_capacity", "rollback"] do |_, args|
 # task "cert_compatibility", ["cert_compatibility_title", "helm_chart_valid", "helm_chart_published", "helm_deploy", "cni_compatible", "increase_decrease_capacity", "rollback"] do |_, args|
   # stdout_score("compatibility", "Compatibility, Installability, and Upgradeability")
   stdout_score(["compatibility", "cert"], "Compatibility, Installability, and Upgradeability")


### PR DESCRIPTION
## Description
Disabling cni_compatible from the list of tests run when using the `cert` command.  

This test is crashing and uses an old k8s version.

This PR does not remove the test from the testsuite.  The test issues will need to be addressed in a different PR.  See the issue #1965 for more details.

## Issues:
Refs: #1965

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
