### PR TITLE
Add removal of pvc in the end of spec test

### DIFF
--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -62,6 +62,7 @@ describe "Microservice" do
     ensure
       result = ShellCmd.run_testsuite("cnf_cleanup cnf-path=sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml")
       result[:status].success?.should be_true
+      KubectlClient::Delete.command("pvc data-test-mariadb-0 -n wordpress")
     end
   end
 


### PR DESCRIPTION
## Description
In one of shared DB spec tests was missing removal of pvc which was created during cnf setup.
This change adds this removal.

## Issues:
Refs: #2017 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
