### PR TITLE
Konst/node drain fix - node-drain: Fix link to experiment #2024

### DIFF
--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -307,12 +307,8 @@ task "node_drain", ["install_litmus"] do |t, args|
             KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/node-drain-experiment.yaml")
             KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/node-drain-rbac.yaml")
           else
-            # experiment_url = "https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/node-drain/experiment.yaml"
-            # https://raw.githubusercontent.com/litmuschaos/chaos-charts/v2.14.x/charts/generic/pod-network-latency/experiment.yaml
-            # https://raw.githubusercontent.com/litmuschaos/chaos-charts/v2.14.x/charts/generic/node-drain/experiment.yaml 
-            experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/charts/generic/node-drain/experiment.yaml"
-            # rbac_url = "https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/node-drain/rbac.yaml"
-            rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/charts/generic/node-drain/rbac.yaml"
+            experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/node-drain/fault.yaml"
+            rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/node-drain/rbac.yaml"
 
             experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
             KubectlClient::Apply.file(experiment_path, namespace: app_namespace)


### PR DESCRIPTION
## Description

node-drain: Fix link to experiment #2024

CI permissions for running specs against https://github.com/cnti-testcatalog/testsuite/pull/2024

## Issues/PR:
Refs: https://github.com/cnti-testcatalog/testsuite/pull/2024