### PR TITLE
Add namespace when calling pods_by_resource

### DIFF
--- a/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
@@ -6,4 +6,5 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 rolling_update_test_tag: 1.6.7
+helm_install_namespace: cnfspace
 allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
@@ -4,4 +4,5 @@ release_name: multi-proc
 helm_repository:
   name:
   repo_url:
+helm_install_namespace: cnfspace
 allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample_coredns/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns/cnf-testsuite.yml
@@ -4,4 +4,5 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
+helm_install_namespace: cnfspace
 allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns_default_namespace/chart
+++ b/sample-cnfs/sample_coredns_default_namespace/chart
@@ -1,0 +1,1 @@
+../sample_coredns/chart

--- a/sample-cnfs/sample_coredns_default_namespace/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_default_namespace/cnf-testsuite.yml
@@ -4,5 +4,5 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-helm_install_namespace: cnfspace
+helm_install_namespace: default
 allowlist_helm_chart_container_names: []

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -353,13 +353,13 @@ describe CnfTestSuite do
 
   it "'default_namespace' should fail if a cnf creates resources in the default namespace", tags: ["default_namespace"] do
     begin
-      result = ShellCmd.run_testsuite("cnf_setup cnf-config=./sample-cnfs/sample_coredns")
+      result = ShellCmd.run_testsuite("cnf_setup cnf-config=./sample-cnfs/sample_coredns_default_namespace")
       result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("default_namespace verbose")
       result[:status].success?.should be_true
       (/(FAILED).*(Resources are created in the default namespace)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=./sample-cnfs/sample_coredns")
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=./sample-cnfs/sample_coredns_default_namespace")
       KubectlClient::Utils.wait_for_terminations()
     end
   end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -312,7 +312,7 @@ task "single_process_type" do |t, args|
       case kind 
       when  "deployment","statefulset","pod","replicaset", "daemonset"
         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
-        pods = KubectlClient::Get.pods_by_resource(resource_yaml)
+        pods = KubectlClient::Get.pods_by_resource(resource_yaml, resource[:namespace])
         containers = KubectlClient::Get.resource_containers(kind, resource[:name], resource[:namespace])
         pods.map do |pod|
           pod_name = pod.dig("metadata", "name")

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -96,7 +96,7 @@ task "prometheus_traffic" do |t, args|
       prom_cnf_match = CNFManager.workload_resource_test(args, config) do |resource_name, container, initialized|
         ip_match = false
         resource = KubectlClient::Get.resource(resource_name[:kind], resource_name[:name], resource_name[:namespace])
-        pods = KubectlClient::Get.pods_by_resource(resource)
+        pods = KubectlClient::Get.pods_by_resource(resource, resource_name[:namespace])
         pods.each do |pod|
           pod_ips = pod.dig("status", "podIPs")
           Log.info { "pod_ips: #{pod_ips}"}


### PR DESCRIPTION
## Description
The namespace is needed to be passed as a parameter when calling pods_by_resource of kubectl client.
Impacted tests: single_process_type, prometheus_traffic Also adding non-default namespace to respective spec tests.

## Issues:
Refs: #2030

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
