### PR TITLE
fix: add error_task into cnf-testsuite-results file

### DIFF
--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -9,6 +9,7 @@ PASSED = "passed"
 FAILED = "failed"
 SKIPPED = "skipped"
 NA = "na"
+ERROR = "error"
 # todo move to helm module
 # CHART_YAML = "Chart.yaml"
 DEFAULT_POINTSFILENAME = "points_v1.yml"

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -15,6 +15,7 @@ module CNFManager
     Neutral
     Pass5
     Pass3
+    Error
 
     def to_basic()
       case self
@@ -159,6 +160,8 @@ module CNFManager
         #   points =points_yml.find {|x| x["name"] == "default_scoring"}
         #   resp = points[field_name].as_i if points
         # end
+      when CNFManager::ResultStatus::Error
+        resp = 0
       else
         resp = dynamic_task_points(task, status.to_s.downcase)
       end

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -132,9 +132,10 @@ module CNFManager
         end
         ret
       rescue ex
-          # platform tests don't have a cnf-config
+        # platform tests don't have a cnf-config
         # Set exception key/value in results
         # file to -1
+        test_start_time = Time.utc
         LOGGING.error ex.message
         ex.backtrace.each do |x|
           LOGGING.error x
@@ -146,6 +147,7 @@ module CNFManager
           exit 2
         else
           Log.info { "exception with skipped exit code" }
+          upsert_decorated_task(test_name, CNFManager::ResultStatus::Error, "Unexpected error occurred", test_start_time)
         end
       end
     end

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -330,6 +330,8 @@ def upsert_decorated_task(task, status : CNFManager::ResultStatus, message, star
     upsert_skipped_task(task, "⏭️  #{cat_emoji}SKIPPED: [#{task}] #{message} #{tc_emoji}", start_time)
   when CNFManager::ResultStatus::NA
     upsert_na_task(task, "⏭️  #{cat_emoji}N/A: [#{task}] #{message} #{tc_emoji}", start_time)
+  when CNFManager::ResultStatus::Error
+    upsert_error_task(task, "💥  #{cat_emoji}ERROR: [#{task}] #{message}", start_time)
   end
 end
 
@@ -356,6 +358,12 @@ def upsert_na_task(task, message, start_time)
   stdout_warning message
   message
 end
+
+def upsert_error_task(task, message, start_time)
+  CNFManager::Points.upsert_task(task, ERROR, CNFManager::Points.task_points(task, CNFManager::ResultStatus::Error), start_time)
+   stdout_error message
+   message
+ end
 
 def upsert_dynamic_task(task, status : CNFManager::ResultStatus, message, start_time)
   CNFManager::Points.upsert_task(task, status.to_s.downcase, CNFManager::Points.task_points(task, status), start_time)
@@ -398,6 +406,10 @@ end
 
 def stdout_failure(msg)
   puts msg.colorize(:red)
+end
+
+def stdout_error(msg)
+  puts msg.colorize(Colorize::Color256.new(208))
 end
 
 def stdout_score(test_name)


### PR DESCRIPTION
## Description
  - add upsert_decorated_task method into single_task_runner
  - if task ends with unexpected error, is also add into results file with status: error

## Issues:
Refs: #1334

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
