### PR TITLE
Add exclusion of init system from single process check

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -42,7 +42,7 @@ shards:
 
   k8s_kernel_introspection:
     git: https://github.com/cnf-testsuite/k8s_kernel_introspection.git
-    version: 1.0.1
+    version: 1.0.2
 
   k8s_netstat:
     git: https://github.com/cnf-testsuite/k8s_netstat.git

--- a/shard.yml
+++ b/shard.yml
@@ -58,7 +58,7 @@ dependencies:
     version: ~> 0.1.0
   k8s_kernel_introspection:
     github: cnf-testsuite/k8s_kernel_introspection
-    version: ~> 1.0.1
+    version: ~> 1.0.2
   helm:
     github: cnf-testsuite/helm
     version: ~> 1.0.1

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -21,6 +21,7 @@ SONOBUOY_OS = "linux"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]
 EMPTY_JSON = JSON.parse(%({}))
 EMPTY_JSON_ARRAY = JSON.parse(%([]))
+SPECIALIZED_INIT_SYSTEMS = ["tini", "dumb-init", "s6-svscan"]
 
 TESTSUITE_NAMESPACE = "cnf-testsuite"
 

--- a/src/tasks/utils/init_systems.cr
+++ b/src/tasks/utils/init_systems.cr
@@ -18,18 +18,9 @@ module InitSystems
   end
   
   def self.is_specialized_init_system?(cmd : String) : Bool
-    # Tests for tini
-    # https://github.com/krallin/tini
-    return true if cmd.includes?("tini")
-  
-    # Tests for dumb-init
-    # https://github.com/Yelp/dumb-init
-    return true if cmd.includes?("dumb-init")
-  
-    # Tests for s6-overlay
-    # https://github.com/just-containers/s6-overlay
-    return true if cmd.includes?("s6-svscan")
-  
+    SPECIALIZED_INIT_SYSTEMS.each do |init_system|
+      return true if cmd.includes?(init_system)
+    end
     # No specialized init system found
     return false
   end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -372,7 +372,8 @@ task "single_process_type" do |t, args|
 
                   verified = KernelIntrospection::K8s::Node.verify_single_proc_tree(ppid, 
                                                                                     status_name, 
-                                                                                    statuses)
+                                                                                    statuses,
+                                                                                    SPECIALIZED_INIT_SYSTEMS)
                   unless verified  
                     Log.for(t.name).info { "multiple proc types detected verified: #{verified}" }
                     fail_msg = "resource: #{resource}, pod #{pod_name} and container: #{container_name} has more than one process type (#{statuses.map{|x|x["cmdline"]?}.compact.uniq.join(", ")})"


### PR DESCRIPTION
## Description
This change defines a list of specialized init systems as a constant and excludes it from the verification of a single process check.
**This PR depends on https://github.com/cnf-testsuite/k8s_kernel_introspection/pull/3 which has to be merge first.**

## Issues:
Refs: #2038

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
