### PR TITLE
Change: Cluster setup exception message shortened

### DIFF
--- a/spec/cluster_setup_spec.cr
+++ b/spec/cluster_setup_spec.cr
@@ -5,7 +5,6 @@ require "kubectl_client"
 require "cluster_tools"
 
 describe "Cluster Setup" do
-
   before_each do
     result = ShellCmd.run_testsuite("cleanup")
     result[:status].success?.should be_true
@@ -15,8 +14,7 @@ describe "Cluster Setup" do
     KubectlClient::Delete.command("namespace #{ClusterTools.namespace}")
     result = ShellCmd.run_testsuite("install_cluster_tools")
     result[:status].success?.should be_false
-    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
-     =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist./ =~ result[:output]).should_not be_nil
   end
   
   it "'install_cluster_tools' should give a message if namespace does not exist even after setup", tags: ["cluster_setup"]  do
@@ -26,15 +24,12 @@ describe "Cluster Setup" do
 
     result = ShellCmd.run_testsuite("install_cluster_tools")
     result[:status].success?.should be_false
-    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
-     =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist./ =~ result[:output]).should_not be_nil
   end
 
   it "'uninstall_cluster_tools' should give a message if namespace does not exist", tags: ["cluster_setup"]  do
     result = ShellCmd.run_testsuite("uninstall_cluster_tools")
     result[:status].success?.should be_false
-    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
-     =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist./ =~ result[:output]).should_not be_nil
   end
-
 end

--- a/spec/cluster_setup_spec.cr
+++ b/spec/cluster_setup_spec.cr
@@ -15,7 +15,8 @@ describe "Cluster Setup" do
     KubectlClient::Delete.command("namespace #{ClusterTools.namespace}")
     result = ShellCmd.run_testsuite("install_cluster_tools")
     result[:status].success?.should be_false
-    (/please run cnf-testsuite setup/ =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
+     =~ result[:output]).should_not be_nil
   end
   
   it "'install_cluster_tools' should give a message if namespace does not exist even after setup", tags: ["cluster_setup"]  do
@@ -25,13 +26,15 @@ describe "Cluster Setup" do
 
     result = ShellCmd.run_testsuite("install_cluster_tools")
     result[:status].success?.should be_false
-    (/please run cnf-testsuite setup/ =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
+     =~ result[:output]).should_not be_nil
   end
 
   it "'uninstall_cluster_tools' should give a message if namespace does not exist", tags: ["cluster_setup"]  do
     result = ShellCmd.run_testsuite("uninstall_cluster_tools")
     result[:status].success?.should be_false
-    (/please run cnf-testsuite setup/ =~ result[:output]).should_not be_nil
+    (/Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace./\
+     =~ result[:output]).should_not be_nil
   end
 
 end

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -14,7 +14,8 @@ task "install_cluster_tools" do |_, args|
     ClusterTools.install
   rescue e : ClusterTools::NamespaceDoesNotExistException 
     Log.info { "#{e.message}" }
-    puts "Please run: cnf-testsuite setup"
+    stdout_failure "Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace."
+    exit(1)
   end
 end
 
@@ -24,6 +25,7 @@ task "uninstall_cluster_tools" do |_, args|
     ClusterTools.uninstall
   rescue e : ClusterTools::NamespaceDoesNotExistException
     Log.info { "#{e.message}" }
-    puts "Please run: cnf-testsuite setup"
+    stdout_failure "Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace."
+    exit(1)
   end
 end

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -10,12 +10,11 @@ require "./utils/utils.cr"
 
 desc "Install CNF Test Suite Cluster Tools"
 task "install_cluster_tools" do |_, args|
-  Log.info { "install_cluster_tools" }
-
   begin
     ClusterTools.install
   rescue e : ClusterTools::NamespaceDoesNotExistException 
-    raise "#{e.message}. please run cnf-testsuite setup!"
+    Log.info { "#{e.message}" }
+    puts "Please run: ./cnf-testsuite setup"
   end
 end
 
@@ -23,7 +22,8 @@ desc "Uninstall CNF Test Suite Cluster Tools"
 task "uninstall_cluster_tools" do |_, args|
   begin
     ClusterTools.uninstall
-  rescue e : ClusterTools::NamespaceDoesNotExistException 
-    raise "#{e.message}. please run cnf-testsuite setup!"
+  rescue e : ClusterTools::NamespaceDoesNotExistException
+    Log.info { "#{e.message}" }
+    puts "Please run: ./cnf-testsuite setup"
   end
 end

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -13,7 +13,7 @@ task "install_cluster_tools" do |_, args|
   begin
     ClusterTools.install
   rescue e : ClusterTools::NamespaceDoesNotExistException 
-    Log.info { "#{e.message}" }
+    Log.error { "#{e.message}" }
     stdout_failure "Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace."
     exit(1)
   end
@@ -24,7 +24,7 @@ task "uninstall_cluster_tools" do |_, args|
   begin
     ClusterTools.uninstall
   rescue e : ClusterTools::NamespaceDoesNotExistException
-    Log.info { "#{e.message}" }
+    Log.error { "#{e.message}" }
     stdout_failure "Error: Namespace cnf-testsuite does not exist.\nPlease run 'cnf-testsuite setup' to create the necessary namespace."
     exit(1)
   end

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -14,7 +14,7 @@ task "install_cluster_tools" do |_, args|
     ClusterTools.install
   rescue e : ClusterTools::NamespaceDoesNotExistException 
     Log.info { "#{e.message}" }
-    puts "Please run: ./cnf-testsuite setup"
+    puts "Please run: cnf-testsuite setup"
   end
 end
 
@@ -24,6 +24,6 @@ task "uninstall_cluster_tools" do |_, args|
     ClusterTools.uninstall
   rescue e : ClusterTools::NamespaceDoesNotExistException
     Log.info { "#{e.message}" }
-    puts "Please run: ./cnf-testsuite setup"
+    puts "Please run: cnf-testsuite setup"
   end
 end


### PR DESCRIPTION
## Description
As explained in the referenced issue, there was an unnecessary stack trace printed out in `install_cluster_tools` and `uninstall_cluster_tools` if `./cnf-testsuite setup` has not been run. This was remediated by replacing the `raise` command with `puts`. Additionally I made the informative message more explicit for new users.

## Issues:
Refs: #1926 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [x] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
