### PR TITLE
[Feature] Make helm_install_namespace default value "cnf-default"

### DIFF
--- a/CNF_TESTSUITE_YML_USAGE.md
+++ b/CNF_TESTSUITE_YML_USAGE.md
@@ -29,7 +29,7 @@ helm_repository: # CONFIGURATION OF HELM REPO - ONLY NEEDED WHEN USING helm_char
 #manifest_directory: coredns # PATH_TO_DIRECTORY_OF_CNFS_MANIFEST_FILES ; or
 release_name: coredns # DESIRED_HELM_RELEASE_NAME
 helm_values: --versions 16.2.0 --set persistence.enabled=false
-helm_install_namespace: cnfspace # Installs the CNF to it's own namespace and not in the default namespace
+helm_install_namespace: cnf-coredns # Installs the CNF to it's own namespace
 
 
 ```
@@ -103,13 +103,15 @@ Example Setting:
 
 #### helm_install_namespace
 
-This sets the namespace that helm will use to install the CNF to. This is to conform to the best practice of not installing your CNF to the `default` namespace on your cluster. You can learn more about this practice [here](./docs/TEST_DOCUMENTATION.md#default-namespaces). This is an optional setting but highly recommended as installing your CNF to use the `default` namespace will result with failed tests.
+This configuration option specifies the namespace that Helm will use to install the CNF. Following best practices, it is recommended not to install your CNF into the `default` namespace of your cluster. For more information on this best practice, see [here](./docs/LIST_OF_TESTS.md#default-namespaces).
 
-You can learn more about kubernetes namespaces [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+This setting is OPTIONAL. If not specified, the CNF will be installed into the `cnf-default` namespace.
+
+For more details about Kubernetes namespaces, visit [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 
 Example Setting:
 
-`helm_install_namespace: cnfspace`
+`helm_install_namespace: your_custom_namespace`
 
 
 #### manifest_directory

--- a/example-cnfs/coredns/cnf-testsuite.yml
+++ b/example-cnfs/coredns/cnf-testsuite.yml
@@ -6,7 +6,6 @@ helm_repository: # CONFIGURATION OF HELM REPO - ONLY NEEDED WHEN USING helm_char
 #helm_directory: coredns # PATH_TO_CNFS_HELM_CHART ; or
 #manifest_directory: coredns # PATH_TO_DIRECTORY_OF_CNFS_MANIFEST_FILES ; or
 release_name: coredns # DESIRED_HELM_RELEASE_NAME
-helm_install_namespace: cnfspace
 container_names:
   - name: coredns
     rolling_update_test_tag: "1.8.0"

--- a/example-cnfs/ip-forwarder/cnf-testsuite.yml
+++ b/example-cnfs/ip-forwarder/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: vpp
 service_name: ""
 rolling_update_test_tag: latest
 allowlist_helm_chart_container_names: [nginx, calico-node, kube-proxy, nginx-proxy, node-cache, kube-multus]
-helm_install_namespace: cnfspace

--- a/example-cnfs/linkerd2/cnf-testsuite.yml
+++ b/example-cnfs/linkerd2/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
     name: linkerd 
     repo_url: https://helm.linkerd.io/stable
 helm_chart: linkerd/linkerd-control-plane
-helm_install_namespace: linkerd

--- a/example-cnfs/nsm/cnf-testsuite.yml
+++ b/example-cnfs/nsm/cnf-testsuite.yml
@@ -5,4 +5,3 @@ service_name: nsm-admission-webhook-svc
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-helm_install_namespace: cnfspace

--- a/example-cnfs/pantheon-nsm-nat/cnf-testsuite.yml
+++ b/example-cnfs/pantheon-nsm-nat/cnf-testsuite.yml
@@ -3,4 +3,3 @@ helm_directory: nat-cnf
 release_name: cnf-nat 
 service_name: 
 allowlist_helm_chart_container_names: [node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy, kube-multus]
-helm_install_namespace: cnfspace

--- a/example-cnfs/vpp-3c2n-csp-use-case/cnf-testsuite.yml
+++ b/example-cnfs/vpp-3c2n-csp-use-case/cnf-testsuite.yml
@@ -2,4 +2,3 @@
 helm_directory: csp
 release_name: ip-forwarder-csp
 allowlist_helm_chart_container_names: [nginx, calico-node, kube-proxy, nginx-proxy, node-cache]
-helm_install_namespace: cnfspace

--- a/sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: chart
-helm_install_namespace: cnfspace
 release_name: sidecar-container-demo
 service_name: 
 helm_repository:

--- a/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-multiple-processes/cnf-testsuite.yml
@@ -6,4 +6,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 rolling_update_test_tag: 1.6.7
-helm_install_namespace: cnfspace

--- a/sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml
+++ b/sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: chart
-helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: 
 release_name: sidecar-container-demo

--- a/sample-cnfs/ndn-reasonable-image-size/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-reasonable-image-size/cnf-testsuite.yml
@@ -1,5 +1,4 @@
 ---
 helm_chart: oci://docker.io/envoyproxy/gateway-helm --version v0.0.0-latest
-helm_install_namespace: "envoy-gateway-system"
 release_name: envoy 
 service_name: envoy

--- a/sample-cnfs/sample-bad-zombie/cnf-testsuite.yml
+++ b/sample-cnfs/sample-bad-zombie/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
-helm_install_namespace: cnfspace

--- a/sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml
@@ -5,4 +5,3 @@ helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
 helm_chart: stable/coredns
-helm_install_namespace: cnfspace

--- a/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
+++ b/sample-cnfs/sample-multiple-processes/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: multi-proc
 helm_repository:
   name:
   repo_url:
-helm_install_namespace: cnfspace

--- a/sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml
+++ b/sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-helm_install_namespace: cnfspace

--- a/sample-cnfs/sample_coredns/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns/cnf-testsuite.yml
@@ -4,4 +4,3 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-helm_install_namespace: cnfspace

--- a/sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml
@@ -1,5 +1,4 @@
 ---
 helm_directory: chart
-helm_install_namespace: cnfspace
 release_name: bad-liveness
 service_name: bad-liveness-coredns 

--- a/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
+++ b/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
@@ -5,5 +5,4 @@ helm_repository:
   name: jenkins
   repo_url: https://charts.jenkins.io
 helm_chart: jenkins/jenkins
-helm_install_namespace: cnfspace
 helm_values: "--set controller.sidecars.configAutoReload.enabled=false"

--- a/sample-cnfs/sample_hostport/cnf-testsuite.yml
+++ b/sample-cnfs/sample_hostport/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: chart
-helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: chart
 release_name: unifi

--- a/sample-cnfs/sample_nodeport/cnf-testsuite.yml
+++ b/sample-cnfs/sample_nodeport/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: chart
-helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: chart
 release_name: unifi

--- a/sample-cnfs/sample_rolling/cnf-testsuite.yml
+++ b/sample-cnfs/sample_rolling/cnf-testsuite.yml
@@ -4,7 +4,6 @@ release_name: coredns
 helm_repository:
   name: stable 
   repo_url: https://cncf.gitlab.io/stable
-helm_install_namespace: cnfspace
 container_names: 
   - name: coredns 
     rolling_update_test_tag: "1.8.0"

--- a/sample-cnfs/sample_secret_volume/cnf-testsuite.yml
+++ b/sample-cnfs/sample_secret_volume/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: postgresql
-helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: chart
 release_name: postgresql

--- a/sample-cnfs/sample_unmounted_secret_volume/cnf-testsuite.yml
+++ b/sample-cnfs/sample_unmounted_secret_volume/cnf-testsuite.yml
@@ -1,6 +1,5 @@
 ---
 helm_directory: postgresql
-helm_install_namespace: cnfspace
 git_clone_url: 
 install_script: chart
 release_name: postgresql

--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -42,8 +42,8 @@ describe "State" do
     begin
       Log.info { "Installing Mysql " }
       # todo make helm directories work with parameters
-      ShellCmd.run_testsuite("cnf_setup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml")
-      KubectlClient::Get.resource_wait_for_install("Pod", "mysql-0")
+      result = ShellCmd.run_testsuite("cnf_setup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml")
+      result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("database_persistence", cmd_prefix: "LOG_LEVEL=info")
       (/(PASSED).*(CNF uses database with cloud-native persistence)/ =~ result[:output]).should_not be_nil
     ensure

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -23,6 +23,7 @@ EMPTY_JSON_ARRAY = JSON.parse(%([]))
 SPECIALIZED_INIT_SYSTEMS = ["tini", "dumb-init", "s6-svscan"]
 
 TESTSUITE_NAMESPACE = "cnf-testsuite"
+DEFAULT_CNF_NAMESPACE = "cnf-default"
 
 #Embedded global text variables
 EmbeddedFileManager.node_failure_values

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -38,7 +38,7 @@ rolling_version_change_test_names.each do |tn|
       # note: all images are not on docker hub nor are they always on a docker hub compatible api
 
       task_response = update_applied && CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-        namespace = resource["namespace"] || config.cnf_config[:helm_install_namespace]
+        namespace = resource["namespace"] || CNFManager.get_deployment_namespace(config)
         test_passed = true
         valid_cnf_testsuite_yml = true
         Log.for(t.name).debug { "container: #{container}" }
@@ -110,7 +110,7 @@ task "rollback" do |t, args|
     task_response = update_applied && CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
         resource_kind = resource["kind"]
         resource_name = resource["name"]
-        namespace = resource["namespace"] || config.cnf_config[:helm_install_namespace]
+        namespace = resource["namespace"] || CNFManager.get_deployment_namespace(config)
         container_name = container.as_h["name"].as_s
         full_image_name_tag = container.as_h["image"].as_s.rpartition(":")
         image_name = full_image_name_tag[0]

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -356,7 +356,7 @@ task "secrets_used" do |t, args|
       #  but do not have a corresponding k8s secret defined, this
       #  is an installation problem, and does not stop the test from passing
 
-      namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       secrets = KubectlClient::Get.secrets(namespace: namespace)
 
       secrets["items"].as_a.each do |s|
@@ -565,7 +565,7 @@ task "immutable_configmap" do |t, args|
 
         # If the install type is manifest, the namesapce would be in the manifest.
         # Else rely on config for helm-based install
-        namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+        namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
         configmaps = KubectlClient::Get.configmaps(namespace: namespace)
         if configmaps.dig?("items")
           configmaps = configmaps.dig("items").as_a

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -679,11 +679,8 @@ task "service_discovery" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args,config|
     # Get all resources for the CNF
     resource_ymls = CNFManager.cnf_workload_resources(args, config) { |resource| resource }
-    default_namespace = "default"
-    if !config.cnf_config[:helm_install_namespace].empty?
-      default_namespace = config.cnf_config[:helm_install_namespace]
-    end
-    resources = Helm.workload_resource_kind_names(resource_ymls, default_namespace)
+    deployment_namespace = CNFManager.get_deployment_namespace(config)
+    resources = Helm.workload_resource_kind_names(resource_ymls, default_namespace: deployment_namespace)
 
     # Collect service names from the CNF resource list
     cnf_service_names = [] of String

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -90,7 +90,7 @@ task "pod_network_latency", ["install_litmus"] do |t, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       Log.info { "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]}" }
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
 
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0 && resource["kind"] == "Deployment"
@@ -188,7 +188,7 @@ task "pod_network_corruption", ["install_litmus"] do |t, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       Log.info {"Current Resource Name: #{resource["name"]} Type: #{resource["kind"]}"}
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0 && resource["kind"] == "Deployment"
         test_passed = true
@@ -241,7 +241,7 @@ task "pod_network_duplication", ["install_litmus"] do |t, args|
     #TODO tests should fail if cnf not installed
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       Log.info{ "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]} Namespace: #{resource["namespace"]}"}
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0 && resource["kind"] == "Deployment"
@@ -296,7 +296,7 @@ task "disk_fill", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
         test_passed = true
@@ -354,7 +354,7 @@ task "pod_delete", ["install_litmus"] do |t, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     #todo clear all annotations
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
         test_passed = true
@@ -454,7 +454,7 @@ task "pod_memory_hog", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
         test_passed = true
@@ -512,7 +512,7 @@ task "pod_io_stress", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
         test_passed = true
@@ -577,7 +577,7 @@ task "pod_dns_error", ["install_litmus"] do |t, args|
     Log.info { "pod_dns_error runtimes: #{runtimes}" }
     if runtimes.find{|r| r.downcase.includes?("docker")}
       task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-        app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+        app_namespace = resource[:namespace] || CNFManager.get_deployment_namespace(config)
         spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
         if spec_labels.as_h? && spec_labels.as_h.size > 0
           test_passed = true


### PR DESCRIPTION
- remove helm_install_namespace from all samples except coredns samples
- cnfs are deployed into cnf-default namespace
- add condition into cleanup to terminate pods from cnf-default namespace
- update ## helm_install_namespaces section in CNF_TESTSUITE_YML_USAGE.md file

## Description
The best practice is not installing CNF to the `default` namespace on cluster.

## Issues:
Refs: #2039

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
