### PR TITLE
Don't fail on delete cluster in github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -202,6 +202,7 @@ jobs:
         kind delete cluster --name $CLUSTER
         docker container prune -f || true
         docker volume prune -f || true
+      continue-on-error: true
         
   chaos:
     name: Chaos & Oran Tests
@@ -401,6 +402,7 @@ jobs:
         docker container prune -f || true
         docker volume prune -f || true
         docker network prune -f || true
+      continue-on-error: true
 
   test_binary_microservice:
     name: Test Binary Without Source(microservice)
@@ -475,6 +477,7 @@ jobs:
         docker container prune -f || true
         docker volume prune -f || true
         docker network prune -f || true
+      continue-on-error: true
 
   test_binary_all:
     name: Test Binary Without Source(all)
@@ -549,6 +552,7 @@ jobs:
         docker container prune -f || true
         docker volume prune -f || true
         docker network prune -f || true
+      continue-on-error: true
 
   release:
     name: Publish Release


### PR DESCRIPTION
Don't fail on unsuccessful cluster deletion.
This unnecessary make the jobs failing.

Refs: #2064

## Description
(name of issue/change)

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
