### PR TITLE
Allow GH actions on PRs from forked repos

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -167,7 +167,7 @@ jobs:
         export PROTECTED_DOCKERHUB_EMAIL=${EMAIL_ARRAY[$RANDOMIZER]}
         export PROTECTED_IMAGE_REPO=${IMAGE_ARRAY[$RANDOMIZER]}
 
-        docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        [[ ! -z  "$DOCKERHUB_USERNAME" && ! -z "$DOCKERHUB_PASSWORD" ]] && docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
 
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf


### PR DESCRIPTION
Make "docker login" in spec execution optional. Note that it has anyway limited (if any) effect as docker registry mirror cache is used and docker login does not really have expected affect. The registry mirror cache itself needs to be configured with respective credentials. 

## Issues:
Refs: #2066

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
