### PR TITLE
Fix: Optimize single_process_type execution

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -9,8 +9,7 @@ shards:
     version: 1.3.1
 
   cluster_tools:
-    git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 1.0.5
+    git: https://github.com/svteb/cluster_tools.git
 
   commander:
     git: https://github.com/mrrooijen/commander.git
@@ -41,12 +40,10 @@ shards:
     version: 0.9.0+git.commit.f62bfcdfbe65ee31c46c3d9951cee08ac2e0bee0
 
   k8s_kernel_introspection:
-    git: https://github.com/cnf-testsuite/k8s_kernel_introspection.git
-    version: 1.0.2
+    git: https://github.com/svteb/k8s_kernel_introspection.git
 
   k8s_netstat:
-    git: https://github.com/cnf-testsuite/k8s_netstat.git
-    version: 1.0.1
+    git: https://github.com/svteb/k8s_netstat.git
 
   kernel_introspection:
     git: https://github.com/cnf-testsuite/kernel_introspection.git

--- a/shard.lock
+++ b/shard.lock
@@ -9,7 +9,8 @@ shards:
     version: 1.3.1
 
   cluster_tools:
-    git: https://github.com/svteb/cluster_tools.git
+    git: https://github.com/cnf-testsuite/cluster_tools.git
+    version: 1.0.6
 
   commander:
     git: https://github.com/mrrooijen/commander.git
@@ -40,10 +41,12 @@ shards:
     version: 0.9.0+git.commit.f62bfcdfbe65ee31c46c3d9951cee08ac2e0bee0
 
   k8s_kernel_introspection:
-    git: https://github.com/svteb/k8s_kernel_introspection.git
+    git: https://github.com/cnf-testsuite/k8s_kernel_introspection.git
+    version: 1.0.3
 
   k8s_netstat:
-    git: https://github.com/svteb/k8s_netstat.git
+    git: https://github.com/cnf-testsuite/k8s_netstat.git
+    version: 1.0.1
 
   kernel_introspection:
     git: https://github.com/cnf-testsuite/kernel_introspection.git

--- a/shard.yml
+++ b/shard.yml
@@ -51,20 +51,17 @@ dependencies:
     github: cnf-testsuite/kubectl_client
     version: ~> 1.0.7
   cluster_tools:
-    github: cnf-testsuite/cluster_tools
-    version: ~> 1.0.0
+    github: svteb/cluster_tools
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0
   k8s_kernel_introspection:
-    github: cnf-testsuite/k8s_kernel_introspection
-    version: ~> 1.0.2
+    github: svteb/k8s_kernel_introspection
   helm:
     github: cnf-testsuite/helm
     version: ~> 1.0.1
   k8s_netstat:
-    github: cnf-testsuite/k8s_netstat
-    version: ~> 1.0.1
+    github: svteb/k8s_netstat
   release_manager:
     github: cnf-testsuite/release_manager
     branch: main

--- a/shard.yml
+++ b/shard.yml
@@ -51,17 +51,20 @@ dependencies:
     github: cnf-testsuite/kubectl_client
     version: ~> 1.0.7
   cluster_tools:
-    github: svteb/cluster_tools
+    github: cnf-testsuite/cluster_tools
+    version: ~> 1.0.6
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0
   k8s_kernel_introspection:
-    github: svteb/k8s_kernel_introspection
+    github: cnf-testsuite/k8s_kernel_introspection
+    version: ~> 1.0.3
   helm:
     github: cnf-testsuite/helm
     version: ~> 1.0.1
   k8s_netstat:
-    github: svteb/k8s_netstat
+    github: cnf-tetstuite/k8s_netstat
+    version: ~> 1.0.1
   release_manager:
     github: cnf-testsuite/release_manager
     branch: main

--- a/shard.yml
+++ b/shard.yml
@@ -63,7 +63,7 @@ dependencies:
     github: cnf-testsuite/helm
     version: ~> 1.0.1
   k8s_netstat:
-    github: cnf-tetstuite/k8s_netstat
+    github: cnf-testsuite/k8s_netstat
     version: ~> 1.0.1
   release_manager:
     github: cnf-testsuite/release_manager


### PR DESCRIPTION
## Description
The single_process_type / process_check spec tests took on average 1:30:00 to execute (in github actions), this was reduced to around 10-15 minutes. It was caused by incorrect use of libraries which checked unnecessary processes multiple times.

**These two changes need to be merged first:**
cluster_tools change: [#27](https://github.com/cnf-testsuite/cluster_tools/pull/27)
k8s_kernel_introspection change: [#4](https://github.com/cnf-testsuite/k8s_kernel_introspection/pull/4)

Because this pull request makes changes in two libraries, it is rather difficult to verify it through actions. Currently there are changes to the `shards.yaml` and `shards.lock` files which will be removed once the reviewers approve the change and the individual library pull requests are merged.

**For reviewers:**
There are two big changes, the first is the replacement of `workload_resource_test` by `cnf_workload_resources`, both yield resource names, but `workload_resource_test` also yields all the container names per resource, thus we could get resources like this (it also did not return all the containers for some reason?):

```
CNFManager.workload_resource_test(args, config) do |resource, container, initialized|

resource: {kind: "Deployment", name: "nginx-webapp", namespace: "cnfspace"}
resource: {kind: "Deployment", name: "nginx-webapp", namespace: "cnfspace"}
resource: {kind: "Deployment", name: "nginx-webapp", namespace: "cnfspace"}
resource: {kind: "Pod", name: "sidecar-container-demo", namespace: "cnfspace"}
resource: {kind: "Pod", name: "sidecar-container-demo", namespace: "cnfspace"}
```

optimized version:

```
CNFManager.cnf_workload_resources(args, config) do |resource|

resource: {kind: "Deployment", name: "nginx-webapp", namespace: "cnfspace"}
resource: {kind: "Pod", name: "sidecar-container-demo", namespace: "cnfspace"}
```

With this change, we do not iterate over every resource multiple times. The second big change is the addition of pid filtering by cgroups. The previous version was incorrectly checking processes on node instead of a container. This lead to something like this (which makes no sense considering we want verify to processes of specific container).

```
for each container:
         container_node = get_container_node()
         get_all_pids_on_node(container_node)
```

optimized version:

```
for each container:
         container_node = get_container_node()
         get_all_pids_on_container(container, container_node)
```

The cgroup filtering currently depends on `ctr` purely because it was easier to write than `runc` filtering. Considering the fact that the current testsuite depends on containerd runtime (`ctr`) it should not be too problematic and can be changed in the future. Finally, I noticed that the cluster_tools library provided a function that was a copy of the code in `single_process_check`. That same function is also shared by the zombie task which has some unique quirks I will not get too deep into here. That shared function (`ClusterTools.all_containers_by_resource?`) had to be changed slightly so it would not break the zombie task. A better refactor can be considered in the future but it is outside the scope of this pull request.

## Issues:
Refs: #2084

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
