### PR TITLE
manifest_install: Move manifest install to repo

### DIFF
--- a/spec/utils/cnf_install/install_common_spec.cr
+++ b/spec/utils/cnf_install/install_common_spec.cr
@@ -1,0 +1,7 @@
+require "../../spec_helper"
+
+it "'CNFInstall.exclusive_install_method_tags' should return false if install method tags are not exclusive", tags: ["cnf-config"]  do
+    config = CNFManager.parsed_config_file("./spec/fixtures/cnf-testsuite-not-exclusive.yml")
+    resp = CNFInstall.exclusive_install_method_tags?(config)
+    (resp).should be_false 
+end

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -392,12 +392,6 @@ describe "SampleUtils" do
     CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-generic-cnf", verbose: true)
   end
 
-  it "'CNFManager.exclusive_install_method_tags' should return false if install method tags are not exclusive", tags: ["cnf-config"]  do
-    config = CNFManager.parsed_config_file("./spec/fixtures/cnf-testsuite-not-exclusive.yml")
-    resp = CNFManager.exclusive_install_method_tags?(config)
-    (resp).should be_false 
-  end
-
   it "bonus tests should not be includded in the maximum points when a failure occurs", tags: ["cnf-config"]  do
     begin
       # fails because doesn't have a service

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -24,8 +24,8 @@ task "samples_cleanup" do  |_, args|
     cnf_config_file = CNFManager.ensure_cnf_testsuite_yml_path(cnf_config_file)
 
     config = CNFManager.parsed_config_file(cnf_config_file)
-    install_method = CNFManager.cnf_installation_method(config)
-    if install_method[0] == Helm::InstallMethod::ManifestDirectory
+    install_method = CNFInstall.cnf_installation_method(config)
+    if install_method[0] == CNFInstall::InstallMethod::ManifestDirectory
       installed_from_manifest = true
     else
       installed_from_manifest = false

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -37,8 +37,8 @@ task "cnf_cleanup" do |_, args|
     force = false
   end
   config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_testsuite_yml_path(cnf))
-  install_method = CNFManager.cnf_installation_method(config)
-  if install_method[0] == Helm::InstallMethod::ManifestDirectory
+  install_method = CNFInstall.cnf_installation_method(config)
+  if install_method[0] == CNFInstall::InstallMethod::ManifestDirectory
     installed_from_manifest = true
   else
     installed_from_manifest = false

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -1,0 +1,147 @@
+require "../utils.cr"
+
+module CNFInstall
+  enum InstallMethod
+    HelmChart
+    HelmDirectory
+    ManifestDirectory 
+    Invalid
+  end
+
+  def self.install_method_by_config_src(config_src : String) : InstallMethod
+    Log.info { "install_method_by_config_src" }
+    Log.info { "config_src: #{config_src}" }
+    helm_chart_file = "#{config_src}/#{Helm::CHART_YAML}"
+    Log.info { "looking for potential helm_chart_file: #{helm_chart_file}: file exists?: #{File.exists?(helm_chart_file)}" }
+
+    if !Dir.exists?(config_src) 
+      Log.info { "install_method_by_config_src helm_chart selected" }
+      InstallMethod::HelmChart
+    elsif File.exists?(helm_chart_file)
+      Log.info { "install_method_by_config_src helm_directory selected" }
+      InstallMethod::HelmDirectory
+    elsif Dir.exists?(config_src) 
+      Log.info { "install_method_by_config_src manifest_directory selected" }
+      InstallMethod::ManifestDirectory
+    else
+      puts "Error: #{config_src} is neither a helm_chart, helm_directory, or manifest_directory.".colorize(:red)
+      exit 1
+    end
+  end
+
+  def self.cnf_installation_method(config : CNFManager::Config) : Tuple(CNFInstall::InstallMethod, String)
+    Log.info { "cnf_installation_method config : CNFManager::Config" }
+    Log.info { "config_cnf_config: #{config.cnf_config}" }
+    yml_file_path = config.cnf_config[:source_cnf_file]
+    parsed_config_file = CNFManager.parsed_config_file(yml_file_path)
+    cnf_installation_method(parsed_config_file)
+  end
+
+  #Determine, for cnf, whether a helm chart, helm directory, or manifest directory is being used for installation
+  def self.cnf_installation_method(config : Totem::Config) : Tuple(CNFInstall::InstallMethod, String)
+    Log.info { "cnf_installation_method" }
+    Log.info { "cnf_installation_method config: #{config}" }
+    Log.info { "cnf_installation_method config: #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}" }
+    helm_chart = optional_key_as_string(config, "helm_chart")
+    helm_directory = ensure_directory(optional_key_as_string(config, "helm_directory"))
+    manifest_directory = optional_key_as_string(config, "manifest_directory")
+    release_name = optional_key_as_string(config, "release_name")
+    full_helm_directory = ""
+    full_manifest_directory = ""
+    Log.info { "release_name: #{release_name}" }
+    Log.info { "helm_directory: #{helm_directory}" }
+    Log.info { "manifest_directory: #{manifest_directory}" }
+    #todo did this ever work? should be full path to destination.  This is not 
+    # even the relative path
+    if Dir.exists?(helm_directory) 
+      Log.info { "Change helm_directory relative path into full path" }
+      full_helm_directory = Path[CNFManager.sandbox_helm_directory(helm_directory)].expand.to_s
+    elsif Dir.exists?(manifest_directory)
+      Log.info { "Change manifest_directory relative path into full path" }
+      full_manifest_directory = Path[manifest_directory].expand.to_s
+    else
+      Log.info { "Building helm_directory and manifest_directory full paths" }
+      full_helm_directory = Path[CNF_DIR + "/" + release_name + "/" + CNFManager.sandbox_helm_directory(helm_directory)].expand.to_s
+      full_manifest_directory = Path[CNF_DIR + "/" + release_name + "/" + CNFManager.sandbox_helm_directory(manifest_directory)].expand.to_s
+    end
+
+    Log.info { "full_helm_directory: #{full_helm_directory} exists? #{Dir.exists?(full_helm_directory)}" }
+    Log.info { "full_manifest_directory: #{full_manifest_directory} exists? #{Dir.exists?(full_manifest_directory)}" }
+
+    unless exclusive_install_method_tags?(config)
+      puts "Error: Must populate at lease one installation type in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}: choose either helm_chart, helm_directory, or manifest_directory in cnf-testsuite.yml!".colorize(:red)
+      exit 1
+    end
+
+    if !helm_chart.empty?
+      {CNFInstall::InstallMethod::HelmChart, helm_chart}
+    elsif !helm_directory.empty?
+      Log.info { "helm_directory not empty, using: #{full_helm_directory}" }
+      {CNFInstall::InstallMethod::HelmDirectory, full_helm_directory}
+    elsif !manifest_directory.empty?
+      Log.info { "manifest_directory not empty, using: #{full_manifest_directory}" }
+      {CNFInstall::InstallMethod::ManifestDirectory, full_manifest_directory}
+    else
+      puts "Error: Must populate at lease one installation type in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}: choose either helm_chart, helm_directory, or manifest_directory.".colorize(:red)
+      exit 1
+    end
+  end
+
+  def self.exclusive_install_method_tags?(config)
+    installation_type_count = ["helm_chart", "helm_directory", "manifest_directory"].reduce(0) do |acc, install_type|
+      begin
+        test_tag = config[install_type]
+        Log.debug { "install type count install_type: #{install_type}" }
+        if install_type.empty?
+          acc
+        else
+          acc = acc + 1
+        end
+      rescue ex
+        Log.debug { "install_type: #{install_type} not found in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}" }
+        acc
+      end
+    end
+    Log.debug { "installation_type_count: #{installation_type_count}" }
+    if installation_type_count > 1
+      false
+    else
+      true
+    end
+  end
+
+  def self.install_parameters(config)
+    Log.info { "install_parameters" }
+    install_method = config.cnf_config[:install_method]
+    helm_chart = config.cnf_config[:helm_chart]
+    helm_directory = config.cnf_config[:helm_directory]
+    manifest_directory = config.cnf_config[:manifest_directory]
+    case install_method[0]
+    when CNFInstall::InstallMethod::ManifestDirectory
+      directory_parameters = directory_parameter_split(manifest_directory)["parameters"]
+    when CNFInstall::InstallMethod::HelmChart
+      directory_parameters = directory_parameter_split(helm_chart)["parameters"]
+    when CNFInstall::InstallMethod::HelmDirectory
+      directory_parameters = directory_parameter_split(helm_directory)["parameters"]
+    else
+      directory_parameters = ""
+    end
+    Log.info { "directory_parameters :#{directory_parameters}" }
+    directory_parameters
+  end
+
+  def self.directory_parameter_split(directory_with_parameters)
+    Log.info { "directory_parameter_split : #{directory_with_parameters}" }
+    directory = directory_with_parameters.split(" ")[0]
+    parameters = directory_with_parameters.split(" ")[1..-1].join(" ") 
+    Log.info { "directory : #{directory} parameters: #{parameters}"} 
+    {"directory" => directory, "parameters" => parameters} 
+  end
+
+  def self.ensure_directory(directory_with_parameters)
+    Log.info { "directory_parameter_split : #{directory_with_parameters}" }
+    split = directory_parameter_split(directory_with_parameters)
+    split["directory"]
+  end
+
+end

--- a/src/tasks/utils/cnf_installation/manifest.cr
+++ b/src/tasks/utils/cnf_installation/manifest.cr
@@ -1,0 +1,51 @@
+module CNFInstall
+  module Manifest
+    def self.parse_manifest_as_ymls(template_file_name="cnfs/temp_template.yml")
+      Log.info { "parse_manifest_as_ymls template_file_name: #{template_file_name}" }
+      templates = File.read(template_file_name)
+      split_template = templates.split(/(\s|^)---(\s|$)/)
+      ymls = split_template.map { | template |
+        #TODO strip out NOTES
+        YAML.parse(template)
+        # compact seems to have problems with yaml::any
+      }.reject{|x|x==nil}
+      Log.debug { "read_template ymls: #{ymls}" }
+      ymls
+    end
+    
+    def self.manifest_ymls_from_file_list(manifest_file_list)
+      ymls = manifest_file_list.map do |x|
+        parse_manifest_as_ymls(x)
+      end
+      ymls.flatten
+    end
+    
+    def self.manifest_file_list(manifest_directory, silent=false)
+      Log.info { "manifest_file_list" }
+      Log.info { "manifest_directory: #{manifest_directory}" }
+      if manifest_directory && !manifest_directory.empty? && manifest_directory != "/"
+        cmd = "find #{manifest_directory}/ -name \"*.yml\" -o -name \"*.yaml\""
+        Log.info { cmd }
+        Process.run(
+          cmd,
+          shell: true,
+          output: find_resp = IO::Memory.new,
+          error: find_err = IO::Memory.new
+        )
+        manifests = find_resp.to_s.split("\n").select{|x| x.empty? == false}
+        Log.info { "find response: #{manifests}" }
+        if manifests.size == 0 && !silent
+          raise "No manifest ymls found in the #{manifest_directory} directory!"
+        end
+        manifests
+      else
+        [] of String
+      end
+    end
+    
+    def self.manifest_containers(manifest_yml)
+      Log.debug { "manifest_containers: #{manifest_yml}" }
+      manifest_yml.dig?("spec", "template", "spec", "containers")
+    end
+  end
+end

--- a/src/tasks/utils/config.cr
+++ b/src/tasks/utils/config.cr
@@ -17,7 +17,7 @@ module CNFManager
                                      source_cnf_file: String,
                                      source_cnf_dir: String,
                                      yml_file_path: String,
-                                     install_method: Tuple(Helm::InstallMethod, String),
+                                     install_method: Tuple(CNFInstall::InstallMethod, String),
                                      manifest_directory: String,
                                      helm_directory: String, 
                                      source_helm_directory: String, 
@@ -70,7 +70,7 @@ module CNFManager
 
       CNFManager.generate_and_set_release_name(config_yml_path)
       config = CNFManager.parsed_config_file(yml_file)
-      install_method = CNFManager.cnf_installation_method(config)
+      install_method = CNFInstall.cnf_installation_method(config)
 
       destination_cnf_dir = CNFManager.cnf_destination_dir(yml_file)
 
@@ -217,18 +217,18 @@ module CNFManager
                                image_registry_fqdns: image_registry_fqdns,})
 
     end
-    def self.install_method_by_config_file(config_file) : Helm::InstallMethod
+    def self.install_method_by_config_file(config_file) : CNFInstall::InstallMethod
       LOGGING.info "install_data_by_config_file"
       config = CNFManager.parsed_config_file(config_file)
       sandbox_config = CNFManager::Config.parse_config_yml(CNFManager.ensure_cnf_testsuite_yml_path(config_file)) 
-      install_method = CNFManager.cnf_installation_method(config)
+      install_method = CNFInstall.cnf_installation_method(config)
       install_method[0]
     end
     def self.config_src_by_config_file(config_file) : String
       LOGGING.info "install_data_by_config_file"
       config = CNFManager.parsed_config_file(config_file)
       sandbox_config = CNFManager::Config.parse_config_yml(CNFManager.ensure_cnf_testsuite_yml_path(config_file)) 
-      install_method = CNFManager.cnf_installation_method(config)
+      install_method = CNFInstall.cnf_installation_method(config)
       install_method[1]
     end
     def self.release_name_by_config_file(config_file) : String

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -68,7 +68,7 @@ module CNFManager
                                             source_cnf_file: "",
                                             source_cnf_dir: "",
                                             yml_file_path: "",
-                                            install_method: {Helm::InstallMethod::HelmChart, ""},
+                                            install_method: {CNFInstall::InstallMethod::HelmChart, ""},
                                             manifest_directory: "",
                                             helm_directory: "", 
                                             source_helm_directory: "",

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -35,7 +35,7 @@ task "shared_database", ["install_cluster_tools"] do |t, args|
     resource_ymls = CNFManager.cnf_workload_resources(args, config) { |resource| resource }
     resource_names = Helm.workload_resource_kind_names(resource_ymls)
     helm_chart_cnf_services : Array(JSON::Any)
-    # namespace = CNFManager.namespace_from_parameters(CNFManager.install_parameters(config))
+    # namespace = CNFManager.namespace_from_parameters(CNFInstall.install_parameters(config))
     # Log.info { "namespace: #{namespace}"}
     helm_chart_cnf_services = resource_names.map do |resource_name|
       Log.info { "helm_chart_cnf_services resource_name: #{resource_name}"}

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -369,7 +369,7 @@ task "elastic_volumes" do |t, args|
 
       # todo use workload resource
       # elastic = WorkloadResource.elastic?(volumes)
-      namespace = CNFManager.namespace_from_parameters(CNFManager.install_parameters(config))
+      namespace = CNFManager.namespace_from_parameters(CNFInstall.install_parameters(config))
 
       full_resource = KubectlClient::Get.resource(resource["kind"], resource["name"], namespace)
       elastic_result = WorkloadResource.elastic?(full_resource, volumes.as_a, namespace)


### PR DESCRIPTION
## Description
Problem explained in referenced issue.

Move "installation methods" enum from helm repo
Move Manifest-related functionality ("Manifest" module) from helm repo

## Issues:
Refs: #2105
