### PR TITLE
workflow: Cancel workflows on push

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,6 +12,11 @@ on:
       - '!**.md'
       - '!docs/*'
       - '!doc-lint/*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Fetch Matrix Tests


### PR DESCRIPTION
## Description

In our CICD, when new commit is pushed (or amended) while workflow for old one is still running - there is no auto-cancelation. Old workflows have to be canceled manually by maintainers to avoid unneccessary waiting.

This change fixes that issue by grouping workflows by PR number or branch ref (in case for push event), and if new workflow is ran in the same group - old one would be automatically cancelled.

Change is relatively simple, so issue wasn't created for it.