### PR TITLE
fix: Change Helm library to CNFInstall module

### DIFF
--- a/sample-cnfs/sample-local-storage/chart/templates/persistent-volume-claim.yaml
+++ b/sample-cnfs/sample-local-storage/chart/templates/persistent-volume-claim.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: foo-pvc
-  namespace: default
 spec:
   storageClassName: local-storage
   accessModes:

--- a/sample-cnfs/sample-oran-noric/manifests/ric.yml
+++ b/sample-cnfs/sample-oran-noric/manifests/ric.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: flexric
+  namespace: oran
   labels:
     app.kubernetes.io/name: flexric
 spec:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flexric
+  namespace: oran
 spec:
   ports:
   - name: ric

--- a/sample-cnfs/sample-oran-noric/manifests/srsran.yml
+++ b/sample-cnfs/sample-oran-noric/manifests/srsran.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: srsran
+  namespace: oran
 spec:
   containers:
   - name: srsran

--- a/sample-cnfs/sample-oran-ric/manifests/ric.yml
+++ b/sample-cnfs/sample-oran-ric/manifests/ric.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: flexric
+  namespace: oran
   labels:
     app.kubernetes.io/name: flexric
 spec:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flexric
+  namespace: oran
 spec:
   ports:
   - name: ric

--- a/sample-cnfs/sample-oran-ric/manifests/srsran.yml
+++ b/sample-cnfs/sample-oran-ric/manifests/srsran.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: srsran
+  namespace: oran
 spec:
   containers:
   - name: srsran

--- a/sample-cnfs/sample-tracing/cnf-testsuite.yml
+++ b/sample-cnfs/sample-tracing/cnf-testsuite.yml
@@ -1,6 +1,7 @@
 ---
 helm_directory: jaeger
 release_name: test
+helm_install_namespace: jaeger
 helm_repository:
   name: jaegertracing 
   repo_url: https://jaegertracing.github.io/helm-charts

--- a/sample-cnfs/sample_open5gs/cnf-testsuite.yml
+++ b/sample-cnfs/sample_open5gs/cnf-testsuite.yml
@@ -1,6 +1,7 @@
 ---
 helm_directory: open5gs
 release_name: open5gs
+helm_install_namespace: testsuite-5g
 #optional 5gcore tag
 amf_label: app.kubernetes.io/name=amf
 smf_label: app.kubernetes.io/name=smf

--- a/sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml
+++ b/sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml
@@ -1,6 +1,7 @@
 ---
 helm_directory: open5gs
 release_name: open5gs
+helm_install_namespace: oran
 #optional 5gcore tag
 core: app.kubernetes.io/name=amf
 amf_service_name: open5gs-amf-ngap

--- a/spec/5g/ran_spec.cr
+++ b/spec/5g/ran_spec.cr
@@ -20,9 +20,9 @@ describe "5g" do
       result = ShellCmd.run_testsuite("oran_e2_connection verbose")
       (/(PASSED).*(RAN connects to a RIC using the e2 standard interface)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-oran-ric/cnf-testsuite.yml") 
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml") 
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_open5gs/cnf-testsuite.yml") 
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-oran-ric/cnf-testsuite.yml") 
       result[:status].success?.should be_true
     end
   end
@@ -34,7 +34,7 @@ describe "5g" do
       result = ShellCmd.run_testsuite("oran_e2_connection verbose")
       (/(FAILED).*(RAN does not connect to a RIC using the e2 standard interface)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_open5gs/cnf-testsuite.yml") 
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml") 
       result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-oran-noric/cnf-testsuite.yml") 
       result[:status].success?.should be_true

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -394,7 +394,7 @@ describe "SampleUtils" do
     begin
       # fails because doesn't have a service
       ShellCmd.cnf_setup("cnf-path=./sample-cnfs/sample_coredns_values")
-      deployment_containers = KubectlClient::Get.deployment_containers("coredns-coredns")
+      deployment_containers = KubectlClient::Get.resource_containers("deployment", "coredns-coredns", "cnf-default")
       image_tags = KubectlClient::Get.container_image_tags(deployment_containers) 
       Log.info { "image_tags: #{image_tags}" }
       (/1.6.9/ =~ image_tags[0][:tag]).should_not be_nil

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -30,7 +30,7 @@ module CNFInstall
   end
 
   def self.cnf_installation_method(config : CNFManager::Config) : Tuple(CNFInstall::InstallMethod, String)
-    Log.info { "cnf_installation_method config : CNFManager::Config" }
+    Log.info { "cnf_installation_method: #{config.cnf_config[:install_method]}" }
     Log.info { "config_cnf_config: #{config.cnf_config}" }
     yml_file_path = config.cnf_config[:source_cnf_file]
     parsed_config_file = CNFManager.parsed_config_file(yml_file_path)

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -136,7 +136,7 @@ module CNFManager
   def self.get_deployment_namespace(config)
     install_method = CNFInstall.cnf_installation_method(config)
     case install_method[0]
-    when CNFInstall::InstallMethod::HelmChart, Helm::InstallMethod::HelmDirectory
+    when CNFInstall::InstallMethod::HelmChart, CNFInstall::InstallMethod::HelmDirectory
       if !config.cnf_config[:helm_install_namespace].empty?
         Log.info { "deployment namespace was set to: #{config.cnf_config[:helm_install_namespace]}" }
         config.cnf_config[:helm_install_namespace]

--- a/src/tasks/utils/srsran.cr
+++ b/src/tasks/utils/srsran.cr
@@ -43,7 +43,7 @@ module SRSRAN
       Log.info { "ueran_pods: #{ueran_pods}" }
       unless ueran_pods[0]? == nil
         Log.info { "Found ueransim ... deleting" }
-        Helm.delete("ueransim")
+        Helm.delete("ueransim -n testsuite-5g")
       end
       Helm.helm_repo_add("openverso","https://gradiant.github.io/openverso-charts/")
       Helm.fetch("openverso/ueransim-gnb --version 0.2.5 --untar")
@@ -89,9 +89,9 @@ module SRSRAN
       File.write("gnb-ues-values.yaml", ue_values)
       # File.write("gnb-ues-values.yaml", UES_VALUES)
       File.write("#{Dir.current}/ueransim-gnb/resources/ue.yaml", UERANSIM_HELMCONFIG)
-      Helm.install("ueransim #{Dir.current}/ueransim-gnb --values ./gnb-ues-values.yaml")
+      Helm.install("-n testsuite-5g ueransim #{Dir.current}/ueransim-gnb --values ./gnb-ues-values.yaml")
       Log.info { "after helm install" }
-      KubectlClient::Get.resource_wait_for_install("Pod", "ueransim")
+      KubectlClient::Get.resource_wait_for_install("Pod", "ueransim", namespace: "testsuite-5g")
       true
     else
       false

--- a/src/tasks/utils/ueransim.cr
+++ b/src/tasks/utils/ueransim.cr
@@ -3,7 +3,7 @@ module UERANSIM
 
   def self.uninstall
     Log.for("verbose").info { "uninstall_ueransim" } 
-    Helm.delete("ueransim")
+    Helm.delete("ueransim -n testsuite-5g")
   end
 
 
@@ -38,7 +38,7 @@ module UERANSIM
       Log.info { "ueran_pods: #{ueran_pods}" }
       unless ueran_pods[0]? == nil
         Log.info { "Found ueransim ... deleting" }
-        Helm.delete("ueransim")
+        Helm.delete("ueransim -n testsuite-5g")
       end
       #Helm.helm_repo_add("openverso","https://gradiant.github.io/openverso-charts/")
       # Helm.fetch("openverso/ueransim-gnb --version 0.2.5 --untar")
@@ -85,9 +85,10 @@ module UERANSIM
       File.write("gnb-ues-values.yaml", ue_values)
       # File.write("gnb-ues-values.yaml", UES_VALUES)
       File.write("#{Dir.current}/ueransim-gnb/resources/ue.yaml", UERANSIM_HELMCONFIG)
-      Helm.install("ueransim #{Dir.current}/ueransim-gnb --values ./gnb-ues-values.yaml")
+      CNFManager.ensure_namespace_exists!("cnf-default")
+      Helm.install("-n testsuite-5g ueransim #{Dir.current}/ueransim-gnb --values ./gnb-ues-values.yaml")
       Log.info { "after helm install" }
-      KubectlClient::Get.resource_wait_for_install("Pod", "ueransim")
+      KubectlClient::Get.resource_wait_for_install("Pod", "ueransim", namespace: "testsuite-5g")
       true
     else
       false

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -160,7 +160,7 @@ task "suci_enabled" do |t, args|
       CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Failed, "Core does not use SUCI 5g authentication")
     end
   ensure
-    Helm.delete("ueransim")
+    Helm.delete("ueransim -n testsuite-5g")
     ClusterTools.install
   end
 


### PR DESCRIPTION
## Description
- affect CNFs that installing method is HelmDirectory
- CNFs are correctly install into cnf-default namespace (if helm_install_namespace variable is not set)
- change Helm::InstallMethod::HelmDirectory to CNFInstall::InstallMethod::HelmDirectory

## Issues:
Refs: #2039

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
