### PR TITLE
Update links to the cnti slack channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,7 @@ The CNTI Test Catalog is [Apache 2.0 licensed](LICENSE) and accepts contribution
 Support channels include:
 
 - [Issues](../../issues)
-- Join the conversation on [LFN Tech's Slack](https://lfntech.slack.com/) channels
-  - [#cnti-testcatalog-testsuite](https://lfntech.slack.com/archives/C06GM6ZEPUP)
-  - [#cnti-testsuite-dev](https://lfntech.slack.com/archives/C06HQGWK4NL)
+- Join the conversation on [LFN Tech's Slack](https://lfntech.slack.com/) [#cnti](https://lfntech.slack.com/archives/C06HQGWK4NL) channel
 
 Before starting work on a major feature, please reach out to us via [GitHub Issues](../../issues) or Slack. We will make sure no one else is already working on it and ask you to open a [GitHub issue](../../issues/new/choose).
 

--- a/CONTRIBUTION_LADDER.md
+++ b/CONTRIBUTION_LADDER.md
@@ -25,7 +25,7 @@ How you can learn more?
 
 * Read the [install guide](INSTALL.md), [usage guide](USAGE.md), [FAQ](FAQ.md), and other documentation
 * Request a live demonstration and introduction of the test suite ([book a time on Calendly](https://calendly.com/cnftestsuite))
-* Come chat with us in [Slack](https://cloud-native.slack.com/archives/C014TNCEX8R) or start a [discussion](https://github.com/cnti-testcataglog/testsuite/discussions)
+* Come chat with us in [Slack](https://lfntech.slack.com/archives/C06HQGWK4NL) or start a [discussion](https://github.com/cnti-testcataglog/testsuite/discussions)
 
 ## Community Participant
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -29,7 +29,7 @@
 <details> <summary>Does CNF Test Suite have a slack channel?</summary>
 <p>
 
-- Yes. We have two channels on [https://slack.cncf.io/](https://slack.cncf.io/), cnf-testsuite and cnf-testsuite-dev.
+- Yes. We have a channel on [LFN Tech's Slack](https://lfntech.slack.com/) [#cnti](https://lfntech.slack.com/archives/C06HQGWK4NL).
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -50,12 +50,7 @@ Welcome! We gladly accept contributions on new tests, example CNFs, updates to d
 
 ## Communication and community meetings
 
-- Join the conversation on [LFN Tech's Slack](https://lfntech.slack.com/) channels
-  - [#cnti-general](https://lfntech.slack.com/archives/C06GV633PRD)
-  - [#cnti-bestpractices](https://lfntech.slack.com/archives/C06GV4J8S5U)
-  - [#cnti-testcatalog-testsuite](https://lfntech.slack.com/archives/C06GM6ZEPUP)
-  - [#cnti-testsuite-dev](https://lfntech.slack.com/archives/C06HQGWK4NL)
-  - [#cnti-certification](https://lfntech.slack.com/archives/C06GYRL5ZPX)
+- Join the conversation on [LFN Tech's Slack](https://lfntech.slack.com/) channel [#cnti](https://lfntech.slack.com/archives/C06HQGWK4NL)
 - Join the weekly CNTI Test Catalog meeting
   - Meetings every Tuesday at 8:00am - 9:00am Pacific Time 
   - Meeting minutes are [here](https://docs.google.com/document/d/1yjL079TR0L1q__BRuhREeXfx5MtAmjPzbFZlZUeBsK4/edit)


### PR DESCRIPTION
Cnti channels were reduced to a single one.
Adapting documentation accordingly.

Refs: lfn-cnti/cnti#32

