### PR TITLE
Bump cluster-tools to v1.0.7

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 1.0.6
+    version: 1.0.7
 
   commander:
     git: https://github.com/mrrooijen/commander.git

--- a/shard.yml
+++ b/shard.yml
@@ -52,7 +52,7 @@ dependencies:
     version: ~> 1.0.7
   cluster_tools:
     github: cnf-testsuite/cluster_tools
-    version: ~> 1.0.6
+    version: ~> 1.0.7
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0


### PR DESCRIPTION
Optimizing cluster-tools for download amount/speed. 

Refs: cnf-testsuite/cluster_tools#24
