### PR TITLE
Feature: CNF Installation (4) Group several manifest into one file

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   find:
     git: https://github.com/cnf-testsuite/find.git
-    version: 0.1.0+git.commit.129096c08d84adb1b741aa8a5ee132d6f2a87e02
+    version: 0.1.0
 
   git:
     git: https://github.com/cnf-testsuite/git.git
@@ -29,19 +29,19 @@ shards:
     version: 0.12.1
 
   helm:
-    git: https://github.com/cnf-testsuite/helm.git
+    git: https://github.com/barmull/helm
     version: 1.0.2
 
   icr:
     git: https://github.com/crystal-community/icr.git
-    version: 0.9.0+git.commit.f62bfcdfbe65ee31c46c3d9951cee08ac2e0bee0
+    version: 0.9.0
 
   k8s_kernel_introspection:
     git: https://github.com/cnf-testsuite/k8s_kernel_introspection.git
     version: 1.0.3
 
   k8s_netstat:
-    git: https://github.com/cnf-testsuite/k8s_netstat.git
+    git: https://github.com/barmull/k8s_netstat
     version: 1.0.1
 
   kernel_introspection:
@@ -62,11 +62,11 @@ shards:
 
   readline:
     git: https://github.com/crystal-lang/crystal-readline.git
-    version: 0.1.1+git.commit.69ecf33d7cad5568d7d19333510cfd9d17cb1bbd
+    version: 0.1.1
 
   release_manager:
     git: https://github.com/cnf-testsuite/release_manager.git
-    version: 0.1.0+git.commit.a1d7b3568d3112f737ab3ff4a7bae69a6b86970a
+    version: 0.1.0
 
   retriable:
     git: https://github.com/sija/retriable.cr.git
@@ -74,11 +74,11 @@ shards:
 
   sam:
     git: https://github.com/vulk/sam.cr.git
-    version: 0.4.0+git.commit.4e3b271d31d7fd3c3ca2b0c1ff4943b86dc27021
+    version: 0.4.0
 
   tar:
     git: https://github.com/cnf-testsuite/tar.git
-    version: 0.1.0+git.commit.ae9bbea1402eded7b411368336653e4ad822003a
+    version: 0.1.0
 
   totem:
     git: https://github.com/icyleaf/totem.git

--- a/shard.yml
+++ b/shard.yml
@@ -60,10 +60,12 @@ dependencies:
     github: cnf-testsuite/k8s_kernel_introspection
     version: ~> 1.0.3
   helm:
-    github: cnf-testsuite/helm
+    github: barmull/helm
+    branch: main
     version: ~> 1.0.1
   k8s_netstat:
-    github: cnf-testsuite/k8s_netstat
+    github: barmull/k8s_netstat
+    branch: main
     version: ~> 1.0.1
   release_manager:
     github: cnf-testsuite/release_manager

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -40,6 +40,12 @@ task "samples_cleanup" do  |_, args|
     )
     nil
   end
+  # Remove common_manifest.yaml file
+  common_manifest_path = "cnfs/common_manifest.yml"
+  if File.exists?(common_manifest_path)
+    File.delete(common_manifest_path)
+    Log.info { "#{common_manifest_path} file deleted successfully." }
+  end
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -30,7 +30,7 @@ module CNFInstall
   end
 
   def self.cnf_installation_method(config : CNFManager::Config) : Tuple(CNFInstall::InstallMethod, String)
-    Log.info { "cnf_installation_method: #{config.cnf_config[:install_method]}" }
+    Log.info { "cnf_installation_method: #{config.cnf_config[:install_method][0]}" }
     Log.info { "config_cnf_config: #{config.cnf_config}" }
     yml_file_path = config.cnf_config[:source_cnf_file]
     parsed_config_file = CNFManager.parsed_config_file(yml_file_path)

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -882,6 +882,10 @@ module CNFManager
     #TODO call kubectl apply on file
     KubectlClient::Apply.file(configmap_path)
     # TODO when uninstalling, remove config map
+    
+    #Generating manifest from installed CNF
+    CNFInstall::Manifest.generate_manifest(config, release_name, deployment_namespace)
+      
   ensure
     #todo uninstall/reinstall clustertools because of tshark bug
   end


### PR DESCRIPTION
## Description
- group manifests from several CNFs into one common_manifests.yaml file
- add functionality in cleanup.cr to remove this file

## Depending on
Pull request from helm library: https://github.com/cnf-testsuite/helm/pull/4

## Issues:
Refs: #2125 

## How has this been tested:
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster