### PR TITLE
Feature: CNF Installation (4) Group several manifest into one file

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   helm:
     git: https://github.com/cnf-testsuite/helm.git
-    version: 1.0.2
+    version: 1.0.3
 
   icr:
     git: https://github.com/crystal-community/icr.git

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -4,6 +4,7 @@ ESSENTIAL_PASSED_THRESHOLD = 15
 CNF_DIR = "cnfs"
 CONFIG_FILE = "cnf-testsuite.yml"
 BASE_CONFIG = "./config.yml"
+COMMON_MANIFEST_FILE_PATH = "#{CNF_DIR}/common_manifest.yml"
 PASSED = "passed"
 FAILED = "failed"
 SKIPPED = "skipped"

--- a/src/tasks/utils/cnf_installation/manifest.cr
+++ b/src/tasks/utils/cnf_installation/manifest.cr
@@ -1,21 +1,34 @@
 module CNFInstall
   module Manifest
-    def self.parse_manifest_as_ymls(template_file_name="cnfs/temp_template.yml")
-      Log.info { "parse_manifest_as_ymls template_file_name: #{template_file_name}" }
-      templates = File.read(template_file_name)
-      split_template = templates.split(/(\s|^)---(\s|$)/)
-      ymls = split_template.map { | template |
-        #TODO strip out NOTES
-        YAML.parse(template)
+    def self.manifest_path_to_ymls(manifest_path)
+      Log.info { "manifest_path_to_ymls file_path: #{manifest_path}" }
+      manifest = File.read(manifest_path)
+      manifest_string_to_ymls(manifest)
+    end
+
+    def self.manifest_string_to_ymls(manifest_string)
+      Log.info { "manifest_string_to_ymls" }
+      split_content = manifest_string.split(/(\s|^)---(\s|$)/)
+      ymls = split_content.map { | manifest |
+        YAML.parse(manifest)
         # compact seems to have problems with yaml::any
       }.reject{|x|x==nil}
-      Log.debug { "read_template ymls: #{ymls}" }
+      Log.debug { "manifest_string_to_ymls:\n #{ymls}" }
       ymls
+    end
+
+    def self.combine_ymls_as_manifest_string(ymls : Array(YAML::Any)) : String
+      Log.info { "combine_ymls_as_manifest_string" }
+      manifest = ymls.map do |yaml_object|
+        yaml_object.to_yaml
+      end.join
+      Log.debug { "combine_ymls_as_manifest:\n #{manifest}" }
+      manifest
     end
     
     def self.manifest_ymls_from_file_list(manifest_file_list)
       ymls = manifest_file_list.map do |x|
-        parse_manifest_as_ymls(x)
+        manifest_path_to_ymls(x)
       end
       ymls.flatten
     end
@@ -46,6 +59,63 @@ module CNFInstall
     def self.manifest_containers(manifest_yml)
       Log.debug { "manifest_containers: #{manifest_yml}" }
       manifest_yml.dig?("spec", "template", "spec", "containers")
+    end
+
+    # Apply namespaces only to resources that are retrieved from Kubernetes as namespaced resource kinds.
+    # Namespaced resource kinds are utilized exclusively during the Helm installation process.
+    def self.add_namespace_to_resources(manifest_string, namespace) 
+      Log.for("add_namespace_to_resources").info { "Updating metadata.namespace field for resources in generated manifest" }
+      namespaced_resources = KubectlClient::ShellCmd.run("kubectl api-resources --namespaced=true --no-headers", "", false).[:output]
+      list_of_namespaced_resources = namespaced_resources.split("\n").select { |item| !item.empty? }
+      list_of_namespaced_kinds = list_of_namespaced_resources.map do |line|
+        line.split(/\s+/).last
+      end
+      parsed_manifest = manifest_string_to_ymls(manifest_string)
+      ymls = [] of YAML::Any
+
+      parsed_manifest.each do |resource|
+        if resource["kind"].as_s.in?(list_of_namespaced_kinds)
+          Helm.ensure_resource_with_namespace(resource, namespace)
+          Log.for("add_namespace_to_resources").info { "Added #{namespace} namespace for resource: {kind: #{resource["kind"]}, name: #{resource["metadata"]["name"]}}" }
+        end
+        ymls << resource
+      end
+
+      string_manifest_with_namespaces = combine_ymls_as_manifest_string(ymls)
+      Log.for("add_namespace_to_resources").debug { "\n#{string_manifest_with_namespaces}" }
+      string_manifest_with_namespaces
+    end
+
+    def self.add_manifest_to_file(deployment_name : String, manifest : String, destination_file)
+      File.open(destination_file, "a+") do |file|
+        file.puts manifest
+        Log.info { "#{deployment_name} manifest was appended into #{destination_file} file" }
+      end
+    end
+    
+    def self.generate_common_manifest(config, deployment_name, namespace)
+      manifest_generated_successfully = true
+      case config.dynamic.install_method[0]
+      when CNFInstall::InstallMethod::ManifestDirectory
+        destination_cnf_dir = config.dynamic.destination_cnf_dir
+        manifest_directory = config.deployments.get_deployment_param(:manifest_directory)
+        list_of_manifests = manifest_file_list( destination_cnf_dir + "/" + manifest_directory )
+        list_of_manifests.each do |manifest_path|
+          manifest = File.read(manifest_path)
+          add_manifest_to_file(deployment_name, manifest, COMMON_MANIFEST_FILE_PATH)
+        end
+      
+      when CNFInstall::InstallMethod::HelmChart, CNFInstall::InstallMethod::HelmDirectory
+        begin
+          generated_manifest = Helm.generate_manifest(deployment_name, namespace)
+          generated_manifest_with_namespaces = add_namespace_to_resources(generated_manifest, namespace)
+          add_manifest_to_file(deployment_name, generated_manifest_with_namespaces, COMMON_MANIFEST_FILE_PATH)
+        rescue ex : Helm::ManifestGenerationError
+          Log.for("generate_common_manifest").error { ex.message }
+          manifest_generated_successfully = false
+        end
+      end
+      manifest_generated_successfully
     end
   end
 end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -26,36 +26,19 @@ module CNFManager
 
   def self.cnf_resource_ymls(args, config)
     Log.info { "cnf_resource_ymls" }
-    template_ymls = [] of YAML::Any
-    case config.dynamic.install_method[0]
-    when CNFInstall::InstallMethod::HelmChart, CNFInstall::InstallMethod::HelmDirectory
-      helm_chart_path = CNFInstall::Config.get_helm_chart_path(config)
-      generated_manifest_file_path = CNFInstall::Config.get_manifest_file_path(config)
-      Log.info { "EXPORTED CHART PATH: #{helm_chart_path}" } 
-      Helm.generate_manifest_from_templates(release_name: config.deployments.get_deployment_param(:name),
-                                            helm_chart: helm_chart_path,
-                                            output_file: generated_manifest_file_path,
-                                            namespace: CNFManager.get_deployment_namespace(config),
-                                            helm_values: config.deployments.get_deployment_param(:helm_values))
-      template_ymls = CNFInstall::Manifest.parse_manifest_as_ymls(generated_manifest_file_path)
-      
-    when CNFInstall::InstallMethod::ManifestDirectory
-      template_ymls = CNFInstall::Manifest.manifest_ymls_from_file_list(
-        CNFInstall::Manifest.manifest_file_list(File.join(config.dynamic.destination_cnf_dir, config.deployments.get_deployment_param(:manifest_directory)))
-      )
-    end
+    manifest_ymls = CNFInstall::Manifest.manifest_path_to_ymls(COMMON_MANIFEST_FILE_PATH)
 
-    template_ymls = template_ymls.reject! {|x|
+    manifest_ymls = manifest_ymls.reject! {|x|
       # reject resources that contain the 'helm.sh/hook: test' annotation
       x.dig?("metadata","annotations","helm.sh/hook")
     }
-    Log.debug { "template_ymls: #{template_ymls}" }
-    template_ymls 
+    Log.debug { "cnf_resource_ymls: #{manifest_ymls}" }
+    manifest_ymls 
   end
 
   def self.cnf_resources(args, config, &block)
-    template_ymls = cnf_resource_ymls(args, config)
-    resource_resp = template_ymls.map do | resource |
+    manifest_ymls = cnf_resource_ymls(args, config)
+    resource_resp = manifest_ymls.map do | resource |
       resp = yield resource
       Log.debug { "cnf_workload_resource yield resp: #{resp}" }
       resp
@@ -96,9 +79,9 @@ module CNFManager
 
   def self.cnf_workload_resources(args, config, &block)
     deployment_namespace = CNFManager.get_deployment_namespace(config)
-    template_ymls = cnf_resource_ymls(args, config)
+    manifest_ymls = cnf_resource_ymls(args, config)
     # call cnf cnf_resources to get unfiltered yml
-    resource_ymls = Helm.all_workload_resources(template_ymls, deployment_namespace)
+    resource_ymls = Helm.all_workload_resources(manifest_ymls, deployment_namespace)
     resource_resp = resource_ymls.map do | resource |
       resp = yield resource
       Log.debug { "cnf_workload_resource yield resp: #{resp}" }
@@ -227,32 +210,6 @@ module CNFManager
 
   def self.sandbox_helm_directory(cnf_testsuite_helm_directory)
     cnf_testsuite_helm_directory.split("/")[-1]
-  end
-
-  #TODO move to helm module
-  def self.helm_template_header(helm_chart_or_directory : String, template_file="/tmp/temp_template.yml")
-    Log.info { "helm_template_header" }
-    Log.info { "helm_template_header helm_chart_or_directory: #{helm_chart_or_directory}" }
-    helm = Helm::BinarySingleton.helm
-    # generate helm chart release name
-    # use --dry-run to generate yml file
-    Helm.install("--dry-run --generate-name #{helm_chart_or_directory} > #{template_file}")
-    raw_template = File.read(template_file)
-    Log.debug { "raw_template: #{raw_template}" }
-    split_template = raw_template.split("---")
-    template_header = split_template[0]
-    parsed_template_header = YAML.parse(template_header)
-    Log.debug { "parsed_template_header: #{parsed_template_header}" }
-    parsed_template_header
-  end
-
-  #TODO move to helm module
-  def self.helm_chart_template_release_name(helm_chart_or_directory : String, template_file="/tmp/temp_template.yml")
-    Log.info { "helm_chart_template_release_name" }
-    Log.info { "helm_chart_template_release_name helm_chart_or_directory: #{helm_chart_or_directory}" }
-    hth = helm_template_header(helm_chart_or_directory, template_file)
-    Log.info { "helm template (should not be a full path): #{hth}" }
-    hth["NAME"]
   end
 
   def self.config_source_dir(config_file)
@@ -536,6 +493,15 @@ module CNFManager
       else
         raise "Deployment method not found"
       end
+      
+      #Generating manifest from installed CNF
+      #Returns true or false in case when manifest was generated successfully or not
+      manifest_generated_successfully = CNFInstall::Manifest.generate_common_manifest(config, release_name, deployment_namespace)
+      
+      if !manifest_generated_successfully
+        stdout_failure "Manifest generation failed. Check CNF definition (helm charts, values, manifests, etc.)"
+        exit 1
+      end
 
       resource_ymls = cnf_workload_resources(nil, config) do |resource|
         resource
@@ -736,6 +702,10 @@ module CNFManager
   def self.sample_cleanup(config_file, force=false, installed_from_manifest=false, verbose=true)
     Log.info { "sample_cleanup" }
     Log.info { "sample_cleanup installed_from_manifest: #{installed_from_manifest}" }
+
+    FileUtils.rm_rf(COMMON_MANIFEST_FILE_PATH)
+    Log.info { "#{COMMON_MANIFEST_FILE_PATH} file was removed." }
+
     config = CNFInstall::Config.parse_cnf_config_from_file(CNFManager.ensure_cnf_testsuite_yml_path(config_file))
     Log.for("verbose").info { "cleanup config: #{config.inspect}" } if verbose
     destination_cnf_dir = config.dynamic.destination_cnf_dir


### PR DESCRIPTION
## Description
- Gather all the manifest files from the various CNFs into a single file called common_manifests.yaml
- Modified temp_template.yaml to reference common_manifests.yaml
- Removed code responsible for generating CNF templates as it is no longer used
- Added functionality in cleanup.cr to remove common_manifests.yaml as part of the cleanup process
- Update generated manifest, add namespace to each resource

- Depends on PR in helm library: https://github.com/cnf-testsuite/helm/pull/4

## Issues:
Refs: #2125 

Re-created from different branch, old PR: #2144 