### PR TITLE
Upgrade ameba to 1.6.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -76,6 +76,6 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.3.1
+    version: ~> 1.6.1
 
 license: MIT


### PR DESCRIPTION
The latest crystal versions ask to upgrade ameba
Please see [1] and [2] for more details.

[1] https://github.com/crystal-ameba/ameba/issues/372
[2] https://github.com/crystal-ameba/ameba/pull/373

## Description

```
# crystal --version
Crystal 1.12.2 (2024-05-31)

LLVM: 17.0.6
Default target: x86_64-alpine-linux-musl
```