### PR TITLE
ameba: Remove ameba from shard dependencies

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -171,14 +171,17 @@ CNF_TESTSUITE_LITMUS_CHAOS_TEST_TIMEOUT=1800
 CNF_TESTSUITE_NODE_DRAIN_TOTAL_CHAOS_DURATION=90
 ```
 
-#### Running The Linter in Developer Mode
+#### Running The Linter
 
-See https://github.com/crystal-ameba/ameba for more details. Follow the [INSTALL](INSTALL.md) guide starting at the [Source Install](INSTALL.md#source-install) for more details running cnf-testsuite in developer mode.
+Ameba (https://github.com/crystal-ameba/ameba) is a static code linter for crystal-lang.
+To run Ameba, you need to install testsuite in developer mode ([Source Install](INSTALL.md#source-install)) and use installation from source method for Ameba, which is mentioned in Ameba readme.md:
 
 ```
-shards install # only for first install
-crystal bin/ameba.cr
+git clone https://github.com/crystal-ameba/ameba && cd ameba
+make install
 ```
+
+After that, follow the usage guidelines from the Ameba repository.
 
 ### Usage for categories and single tests
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -174,7 +174,7 @@ CNF_TESTSUITE_NODE_DRAIN_TOTAL_CHAOS_DURATION=90
 #### Running The Linter
 
 Ameba (https://github.com/crystal-ameba/ameba) is a static code linter for crystal-lang.
-To run Ameba, you need to install testsuite in developer mode ([Source Install](INSTALL.md#source-install)) and use installation from source method for Ameba, which is mentioned in Ameba readme.md:
+To run Ameba, testsuite needs to be installed in developer mode ([Source Install](INSTALL.md#source-install)) and Ameba needs to be installed using source method, which is mentioned in Ameba readme.md:
 
 ```
 git clone https://github.com/crystal-ameba/ameba && cd ameba

--- a/shard.lock
+++ b/shard.lock
@@ -1,9 +1,5 @@
 version: 2.0
 shards:
-  ameba:
-    git: https://github.com/crystal-ameba/ameba.git
-    version: 1.3.1
-
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
     version: 1.0.7

--- a/shard.yml
+++ b/shard.yml
@@ -73,9 +73,4 @@ dependencies:
   protobuf:
     github: jeromegn/protobuf.cr
 
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.3.1
-
 license: MIT


### PR DESCRIPTION
## Description
Ameba is a linting tool, which isn't being used in our CI pipelines, and causes complications with crystal version update. 

Ameba dependency should be removed from cnf-testcatalog shards and usage guidelines should point to more independent usage via installing the linter from source.

## Issues:
Refs: #2157