### PR TITLE
config: CNF installation (3.1) Limit cnf_setup to only one CNF

### DIFF
--- a/spec/5g/ran_spec.cr
+++ b/spec/5g/ran_spec.cr
@@ -5,22 +5,44 @@ require "../../src/tasks/kind_setup.cr"
 require "file_utils"
 require "sam"
 
-describe "5g" do
+def setup_5g_network
+  deployment_names = [
+    "open5gs-amf", "open5gs-ausf", "open5gs-bsf", "open5gs-mongodb", "open5gs-nrf", "open5gs-nssf", 
+    "open5gs-pcf", "open5gs-populate", "open5gs-smf", "open5gs-udm", "open5gs-udr", "open5gs-upf"
+  ]
 
+  # Run Helm install command for the 5G network
+  helm_chart_path = "sample-cnfs/sample_srsran_ueauth_open5gs/open5gs"
+  Helm.install("open5gs #{helm_chart_path} -n oran --create-namespace")
+
+  deployment_names.each do |deployment_name|
+    # Wait for each deployment to be ready
+    ready = KubectlClient::Get.resource_wait_for_install("deployment", deployment_name, namespace: "oran")
+    if !ready
+      stdout_failure "Could not set up the 5g network"
+      return false
+    end
+  end
+
+  stdout_success "Successfully setup open5gs"
+  return true
+end
+
+describe "5g" do
   before_all do
     result = ShellCmd.run_testsuite("setup")
     result[:status].success?.should be_true
   end
 
-
   it "'oran_e2_connection' should pass if the ORAN enabled RAN connects to the RIC using the e2 standard", tags: ["oran"]  do
     begin
-      ShellCmd.cnf_setup("cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml")
+      setup_success = setup_5g_network
+      setup_success.should be_true
       ShellCmd.cnf_setup("cnf-config=sample-cnfs/sample-oran-ric/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("oran_e2_connection verbose")
       (/(PASSED).*(RAN connects to a RIC using the e2 standard interface)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml") 
+      result = Helm.delete("open5gs -n oran") 
       result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-oran-ric/cnf-testsuite.yml") 
       result[:status].success?.should be_true
@@ -29,12 +51,13 @@ describe "5g" do
 
   it "'oran_e2_connection' should fail if the ORAN enabled RAN does not connect to the RIC using the e2 standard", tags: ["oran"]  do
     begin
-      ShellCmd.cnf_setup("cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml")
+      setup_success = setup_5g_network
+      setup_success.should be_true
       ShellCmd.cnf_setup("cnf-config=sample-cnfs/sample-oran-noric/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("oran_e2_connection verbose")
       (/(FAILED).*(RAN does not connect to a RIC using the e2 standard interface)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample_srsran_ueauth_open5gs/cnf-testsuite.yml") 
+      result = Helm.delete("open5gs -n oran") 
       result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-oran-noric/cnf-testsuite.yml") 
       result[:status].success?.should be_true

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -76,4 +76,18 @@ describe "Setup" do
       (/Successfully cleaned up/ =~ result[:output]).should_not be_nil
     end
   end
+
+  it "'cnf_setup' should fail if another CNF is already installed", tags: ["setup"] do
+    begin
+      result = ShellCmd.cnf_setup("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
+      (/Successfully setup coredns/ =~ result[:output]).should_not be_nil
+      result = ShellCmd.cnf_setup("cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml")
+      (/A CNF is already set up. Setting up multiple CNFs is not allowed./ =~ result[:output]).should_not be_nil
+    ensure
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
+      result[:status].success?.should be_true
+      (/Successfully cleaned up/ =~ result[:output]).should_not be_nil
+      result = ShellCmd.run_testsuite("cnf_cleanup cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml")
+    end
+  end
 end


### PR DESCRIPTION
## Description
Remove the ability of users to run `cnf-testsuite cnf_setup {../testsuite.yml}` multiple times.

## Issues:
Refs: #2095 #2120 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
