### PR TITLE
Test Adaptations: CNF Installation (5.3) Disable new cluster tests and adapt service_discovery

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   helm:
     git: https://github.com/cnf-testsuite/helm.git
-    version: 1.0.2
+    version: 1.0.3
 
   icr:
     git: https://github.com/crystal-community/icr.git

--- a/spec/workload/compatibility_spec.cr
+++ b/spec/workload/compatibility_spec.cr
@@ -25,7 +25,8 @@ describe "Compatibility" do
         retries = retries + 1
       end
       Log.info { "Status:  #{result[:output]}" }
-      (/(PASSED).*(CNF compatible with both Calico and Cilium)/ =~ result[:output]).should_not be_nil
+      (/(SKIPPED)).*(alpha_k8s_apis test was temporarily disabled due to needed redesign for cnf_to_new_cluster)/ =~ result[:output]).should_not be_nil
+      #(/(PASSED).*(CNF compatible with both Calico and Cilium)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.run_testsuite("cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
       result[:status].success?.should be_true

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -4,6 +4,7 @@ ESSENTIAL_PASSED_THRESHOLD = 15
 CNF_DIR = "cnfs"
 CONFIG_FILE = "cnf-testsuite.yml"
 BASE_CONFIG = "./config.yml"
+COMMON_MANIFEST_FILE_PATH = "#{CNF_DIR}/common_manifest.yml"
 PASSED = "passed"
 FAILED = "failed"
 SKIPPED = "skipped"

--- a/src/tasks/utils/cnf_installation/manifest.cr
+++ b/src/tasks/utils/cnf_installation/manifest.cr
@@ -1,21 +1,35 @@
 module CNFInstall
   module Manifest
-    def self.parse_manifest_as_ymls(template_file_name="cnfs/temp_template.yml")
-      Log.info { "parse_manifest_as_ymls template_file_name: #{template_file_name}" }
-      templates = File.read(template_file_name)
-      split_template = templates.split(/(\s|^)---(\s|$)/)
-      ymls = split_template.map { | template |
+    def self.manifest_path_to_ymls(manifest_path)
+      Log.info { "manifest_path_to_ymls file_path: #{manifest_path}" }
+      manifest = File.read(manifest_path)
+      manifest_string_to_ymls(manifest)
+    end
+
+    def self.manifest_string_to_ymls(manifest_string)
+      Log.info { "method: manifest_string_to_ymls" }
+      split_content = manifest_string.split(/(\s|^)---(\s|$)/)
+      ymls = split_content.map { | manifest |
         #TODO strip out NOTES
-        YAML.parse(template)
+        YAML.parse(manifest)
         # compact seems to have problems with yaml::any
       }.reject{|x|x==nil}
-      Log.debug { "read_template ymls: #{ymls}" }
+      Log.debug { "manifest_string_to_ymls:\n #{ymls}" }
       ymls
+    end
+
+    def self.combine_ymls_as_manifest_string(ymls : Array(YAML::Any)) : String
+      manifest = ymls.map do |yaml_object|
+        yaml_object.to_yaml
+      end.join
+    
+      Log.debug { "combine_ymls_as_manifest:\n #{manifest}" }
+      manifest
     end
     
     def self.manifest_ymls_from_file_list(manifest_file_list)
       ymls = manifest_file_list.map do |x|
-        parse_manifest_as_ymls(x)
+        manifest_path_to_ymls(x)
       end
       ymls.flatten
     end
@@ -46,6 +60,54 @@ module CNFInstall
     def self.manifest_containers(manifest_yml)
       Log.debug { "manifest_containers: #{manifest_yml}" }
       manifest_yml.dig?("spec", "template", "spec", "containers")
+    end
+
+    def self.add_namespace_to_resource(manifest_string, namespace)
+      namespaced_resources = KubectlClient::ShellCmd.run("kubectl api-resources --namespaced=true --no-headers | awk '{print $(NF)}'", "", false).[:output]
+      list_of_namespaced_resources = namespaced_resources.split("\n").select { |item| !item.empty? }
+      parsed_manifest = manifest_string_to_ymls(manifest_string)
+      ymls = [] of YAML::Any
+      parsed_manifest.each do |resource|
+        if resource["kind"].as_s.in?(list_of_namespaced_resources)
+          Helm.ensure_resource_with_namespace(resource, namespace)
+          ymls << resource
+        else
+          ymls << resource
+        end
+      end
+      string_manifest_with_namespaces = combine_ymls_as_manifest_string(ymls)
+    end
+
+    def self.add_manifest_to_file(deployment_name : String, manifest : String, destination_file)
+      File.open(destination_file, "a+") do |file|
+        file.puts manifest
+        Log.info { "#{deployment_name} manifest was appended into #{destination_file} file" }
+      end
+    end
+    
+    def self.generate_common_manifest(config, deployment_name, namespace)
+      manifest_generated_successfully = true
+      case config.dynamic.install_method[0]
+      when CNFInstall::InstallMethod::ManifestDirectory
+        destination_cnf_dir = config.dynamic.destination_cnf_dir
+        manifest_directory = config.deployments.get_deployment_param(:manifest_directory)
+        list_of_manifests = manifest_file_list( destination_cnf_dir + "/" + manifest_directory )
+        list_of_manifests.each do |manifest_path|
+          manifest = File.read(manifest_path)
+          add_manifest_to_file(deployment_name, manifest, COMMON_MANIFEST_FILE_PATH)
+        end
+      
+      when CNFInstall::InstallMethod::HelmChart, CNFInstall::InstallMethod::HelmDirectory
+        begin
+          generated_manifest = Helm.generate_manifest(deployment_name, namespace)
+          generated_manifest_with_namespaces = add_namespace_to_resource(generated_manifest, namespace)
+          add_manifest_to_file(deployment_name, generated_manifest_with_namespaces, COMMON_MANIFEST_FILE_PATH)
+        rescue ex : Helm::ManifestGenerationError
+          Log.for("generate_common_manifest").error { ex.message }
+          manifest_generated_successfully = false
+        end
+      end
+      manifest_generated_successfully
     end
   end
 end

--- a/src/tasks/utils/k8s_tshark.cr
+++ b/src/tasks/utils/k8s_tshark.cr
@@ -116,7 +116,7 @@ module K8sTshark
 
         # Some tshark captures were left in zombie states if only kill/kill -9 was invoked.
         ClusterTools.exec_by_node_bg("kill -15 #{@pid}", @node_match.not_nil!)
-        sleep 1
+        sleep(1.seconds)
         ClusterTools.exec_by_node_bg("kill -9 #{@pid}", @node_match.not_nil!)
 
         @pid = nil

--- a/src/tasks/utils/timeouts.cr
+++ b/src/tasks/utils/timeouts.cr
@@ -20,7 +20,7 @@ def repeat_with_timeout(timeout, errormsg, reset_on_nil=false, delay=2, &block)
     elsif result
       return true
     end
-    sleep delay
+    sleep(delay.seconds)
     Log.for("verbose").info { "Time left: #{timeout - (Time.utc - start_time).to_i} seconds" }
   end
   Log.error { errormsg }

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -115,7 +115,7 @@ end
 
 def smf_up_heartbeat_capture_matches_count(smf_key : String, smf_value : String, command : String)
   K8sTshark::TsharkPacketCapture.begin_capture_by_label(smf_key, smf_value, command) do |capture|
-    sleep 60
+    sleep(60.seconds)
     capture.regex_search(/"pfcp\.msg_type": "(1|2)"/).size
   end
 end
@@ -135,7 +135,7 @@ task "suci_enabled" do |t, args|
       K8sTshark::TsharkPacketCapture.begin_capture_by_label(core_key, core_value, command) do |capture|
         #todo put in prereq
         UERANSIM.install(config)
-        sleep 30.0
+        sleep(30.0.seconds)
         # TODO 5g RAN (only) mobile traffic check ????
         # use suci encyption but don't use a null encryption key
         suci_found = capture.regex_match?(/"nas_5gs.mm.type_id": "1"/) && \

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -526,6 +526,7 @@ end
 desc "CNFs should work with any Certified Kubernetes product and any CNI-compatible network that meet their functionality requirements."
 task "cni_compatible" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
+    return CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Skipped, "cni_compatible test was temporarily disabled due to needed redesign for cnf_to_new_cluster")
     docker_version = DockerClient.version_info()
     if docker_version.installed?
       ensure_kubeconfig!

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -605,6 +605,7 @@ task "alpha_k8s_apis" do |t, args|
     unless check_poc(args)
       next CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Skipped, "alpha_k8s_apis not in poc mode")
     end
+    return CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Skipped, "alpha_k8s_apis test was temporarily disabled due to needed redesign for cnf_to_new_cluster")
 
     ensure_kubeconfig!
     kubeconfig_orig = ENV["KUBECONFIG"]

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -371,7 +371,7 @@ task "zombie_handled" do |t, args|
       end
     end
 
-    sleep 10.0
+    sleep(10.0.seconds)
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false ) do |resource, container, initialized|
       ClusterTools.all_containers_by_resource?(resource, resource[:namespace], only_container_pids:false) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status| 
@@ -565,7 +565,7 @@ task "sig_term_handled" do |t, args|
               Log.for(t.name).info { "pid_log_names: #{pid_log_names}" }
               #todo 2.3 parse the logs 
               #todo get the log
-              sleep 5
+              sleep(5.seconds)
               sig_term_found = pid_log_names.map do |pid_name|
                 Log.info { "pid_name: #{pid_name}" }
                 resp = File.read("#{pid_name}")

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -631,8 +631,7 @@ task "service_discovery" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args,config|
     # Get all resources for the CNF
     resource_ymls = CNFManager.cnf_workload_resources(args, config) { |resource| resource }
-    deployment_namespace = CNFManager.get_deployment_namespace(config)
-    resources = Helm.workload_resource_kind_names(resource_ymls, default_namespace: deployment_namespace)
+    resources = Helm.workload_resource_kind_names(resource_ymls)
 
     # Collect service names from the CNF resource list
     cnf_service_names = [] of String


### PR DESCRIPTION
## Description
Temporarily disable cnf_to_new_cluster tests as this process needs to be redesigned to new installation format.
Also, adapt service_discovery to namespaced manifest generation.

## Issues:
Refs: #2153