### PR TITLE
Protect kind delete calls

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -197,9 +197,10 @@ jobs:
       run: |
         source cluster.env
         kind export logs --name $CLUSTER /tmp/output-dir
-        kind delete cluster --name $CLUSTER
-        docker container prune -f || true
-        docker volume prune -f || true
+        docker ps -a
+        export KUBECONFIG=$(pwd)/$CLUSTER.conf
+        kubectl get all -A || true
+        kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
     - name: upload artifact
       if: ${{ always() }}
@@ -288,9 +289,10 @@ jobs:
       run: |
         source cluster.env
         kind export logs --name $CLUSTER /tmp/output-dir
-        kind delete cluster --name $CLUSTER
-        docker container prune -f || true
-        docker volume prune -f || true
+        docker ps -a
+        export KUBECONFIG=$(pwd)/$CLUSTER.conf
+        kubectl get all -A || true
+        kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
     - name: upload artifact
       if: ${{ always() }}
@@ -401,10 +403,10 @@ jobs:
       run: |
         source cluster.env
         kind export logs --name $CLUSTER /tmp/output-dir
-        kind delete cluster --name $CLUSTER
-        docker container prune -f || true
-        docker volume prune -f || true
-        docker network prune -f || true
+        docker ps -a
+        export KUBECONFIG=$(pwd)/$CLUSTER.conf
+        kubectl get all -A || true
+        kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
     - name: upload artifact
       if: ${{ always() }}
@@ -481,10 +483,10 @@ jobs:
       run: |
         source cluster.env
         kind export logs --name $CLUSTER /tmp/output-dir
-        kind delete cluster --name $CLUSTER
-        docker container prune -f || true
-        docker volume prune -f || true
-        docker network prune -f || true
+        docker ps -a
+        export KUBECONFIG=$(pwd)/$CLUSTER.conf
+        kubectl get all -A || true
+        kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
     - name: upload artifact
       if: ${{ always() }}
@@ -561,10 +563,10 @@ jobs:
       run: |
         source cluster.env
         kind export logs --name $CLUSTER /tmp/output-dir
-        kind delete cluster --name $CLUSTER
-        docker container prune -f || true
-        docker volume prune -f || true
-        docker network prune -f || true
+        docker ps -a
+        export KUBECONFIG=$(pwd)/$CLUSTER.conf
+        kubectl get all -A || true
+        kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
     - name: upload artifact
       if: ${{ always() }}


### PR DESCRIPTION
## Description

Many delete cluster jobs fail by exiting 1 (it's shown as errors in summary).
This changes simply ensure that the next cleanups are done.

Please see https://github.com/cnti-testcatalog/testsuite/actions/runs/12236823830
Annotations 11 errors

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [X] Verified all A/C passes
     * [ ] develop
     * [X] main
     * [ ] tag/other branch
 - [X] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested