### PR TITLE
Upgrade cluster_tools to v1.0.8 in shard.yml

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 1.0.7
+    version: 1.0.8
 
   commander:
     git: https://github.com/mrrooijen/commander.git

--- a/shard.yml
+++ b/shard.yml
@@ -52,7 +52,7 @@ dependencies:
     version: ~> 1.0.7
   cluster_tools:
     github: cnf-testsuite/cluster_tools
-    version: ~> 1.0.7
+    version: ~> 1.0.8
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0


### PR DESCRIPTION
## Description

It includes the fix stopping passing stdin to the container.

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [X] Verified all A/C passes
     * [ ] develop
     * [X] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested