### PR TITLE
Avoid too many pull requests because of skopeo

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,11 +1,8 @@
 name: Crystal Specs
 on:
   push:
-    paths:
+    tags:
       - '**'
-      - '!**.md'
-      - '!docs/*'
-      - '!doc-lint/*'
   pull_request:
     paths:
       - '**'
@@ -61,6 +58,11 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.tests.outputs.matrix)}}
     steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: Cleanup Tmp DIR
       run: |
         sudo rm -rf /tmp/*
@@ -153,25 +155,22 @@ jobs:
     - name: Run Crystal Spec
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DOCKERHUB_USERNAMES: ${{ secrets.DOCKERHUB_USERNAMES }}
-        DOCKERHUB_PASSWORDS: ${{ secrets.DOCKERHUB_PASSWORDS }}
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
         IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
       run: |
-        USERNAME_ARRAY=($DOCKERHUB_USERNAMES)
-        PASSWORD_ARRAY=($DOCKERHUB_PASSWORDS)
         EMAIL_ARRAY=($DOCKERHUB_EMAIL)
         IMAGE_ARRAY=($IMAGE_REPO)
-        
         RANDOMIZER=$(( 0 + $RANDOM % 3 ))
-
-        export DOCKERHUB_USERNAME=${USERNAME_ARRAY[$RANDOMIZER]}
-        export DOCKERHUB_PASSWORD=${PASSWORD_ARRAY[$RANDOMIZER]}
-        
         export PROTECTED_DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME
         export PROTECTED_DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD
         export PROTECTED_DOCKERHUB_EMAIL=${EMAIL_ARRAY[$RANDOMIZER]}
         export PROTECTED_IMAGE_REPO=${IMAGE_ARRAY[$RANDOMIZER]}
+
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
 
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
@@ -186,10 +185,13 @@ jobs:
         #done
         crystal build src/cnf-testsuite.cr 
         ./cnf-testsuite setup 
-
         LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v
-
-
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+        echo get ratelimit with a user account $DOCKERHUB_USERNAME
+        TOKEN=$(curl --user "$DOCKERHUB_USERNAME:$DOCKERHUB_PASSWORD" "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -200,6 +202,7 @@ jobs:
         kubectl get all -A || true
         kind delete cluster --name $CLUSTER --verbosity 1
       continue-on-error: true
+
     - name: upload artifact
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
@@ -274,7 +277,10 @@ jobs:
         echo "RUNNER: $RUNNER_NAME"
     - name: Run Crystal Spec
       run: |
-        echo "Current path: $(echo pwd)"
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         until [[ $(kubectl get pods -l app=kindnet --namespace=kube-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') == "True" ]]; do
@@ -282,6 +288,9 @@ jobs:
             sleep 1
         done
         LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.tag }} -v
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -383,6 +392,10 @@ jobs:
         kubectl get nodes 
     - name: Run Test Suite without source(config_lifecycle)
       run: |
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
         source cluster.env
         echo "SHARDS_INSTALL_PATH: $SHARDS_INSTALL_PATH"
         export KUBECONFIG=/tmp/$CLUSTER.conf
@@ -396,6 +409,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/cnti-testcatalog/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=info ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published verbose
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -464,6 +480,10 @@ jobs:
         kubectl get nodes 
     - name: Run Test Suite without source(microservice)
       run: |
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
         source cluster.env
         export KUBECONFIG=/tmp/$CLUSTER.conf
         helm repo add stable https://cncf.gitlab.io/stable
@@ -476,6 +496,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/cnti-testcatalog/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=info ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~increase_capacity ~decrease_capacity ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap verbose
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -544,6 +567,10 @@ jobs:
         kubectl get nodes 
     - name: Run Test Suite without source(all)
       run: |
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
         source cluster.env
         export KUBECONFIG=/tmp/$CLUSTER.conf
         helm repo add stable https://cncf.gitlab.io/stable
@@ -556,6 +583,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/cnti-testcatalog/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=info ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size verbose
+        echo get ratelimit anonymously
+        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 1.0.8
+    version: 1.0.9
 
   commander:
     git: https://github.com/mrrooijen/commander.git

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 1.0.7
+    version: 1.0.8
 
   commander:
     git: https://github.com/mrrooijen/commander.git

--- a/shard.yml
+++ b/shard.yml
@@ -52,7 +52,7 @@ dependencies:
     version: ~> 1.0.7
   cluster_tools:
     github: cnf-testsuite/cluster_tools
-    version: ~> 1.0.7
+    version: ~> 1.0.8
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0

--- a/shard.yml
+++ b/shard.yml
@@ -52,7 +52,7 @@ dependencies:
     version: ~> 1.0.7
   cluster_tools:
     github: cnf-testsuite/cluster_tools
-    version: ~> 1.0.8
+    version: ~> 1.0.9
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
     version: ~> 0.1.0

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -85,34 +85,6 @@ namespace "platform" do
   end
 end
 
-def skopeo_sha_list(repo)
-  tags = skopeo_tags(repo)
-  Log.info { "sha_list tags: #{tags}" }
-
-  if tags
-    tags.as_a.reduce([] of Hash(String, String)) do |acc, i|
-      acc << {"name" => i.not_nil!.as_s, "manifest_digest" => skopeo_digest("#{repo}:#{i}").as_s}
-    end
-  end
-end
-
-def skopeo_digest(image)
-  ClusterTools.install
-  resp = ClusterTools.exec("skopeo inspect docker://#{image}")
-  Log.info { resp[:output] }
-  parsed_json = JSON.parse(resp[:output])
-  parsed_json["Digest"]
-end
-
-def skopeo_tags(repo)
-  ClusterTools.install
-  resp = ClusterTools.exec("skopeo list-tags docker://#{repo}")
-  Log.info { resp[:output] }
-  parsed_json = JSON.parse(resp[:output])
-  parsed_json["Tags"]
-end
-
-
 def named_sha_list(resp_json)
   Log.debug { "sha_list resp_json: #{resp_json}" }
   parsed_json = JSON.parse(resp_json)


### PR DESCRIPTION
## Description

skopeo directly pulls from docker.io which easily reaches the pull rate limit.

Please see shared_database and observability failing because of skopeo
(whatever the use of private mirror or mirror.gcr.io):

- https://github.com/cnti-testcatalog/testsuite/actions/runs/12674901774/job/35470396257?pr=2203
- https://github.com/cnti-testcatalog/testsuite/actions/runs/12674901774/job/35470398665?pr=2203

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [X] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested