### PR TITLE
Fix: cnf_installation tag was not being discovered after name change

### DIFF
--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -11,7 +11,7 @@ describe "Installation" do
     result = ShellCmd.environment_cleanup()
   end
 
-  it "'setup' should install all cnf-testsuite dependencies before installing cnfs", tags:["cnf_installation"]  do
+  it "'setup' should install all cnf-testsuite dependencies before installing cnfs", tags: ["cnf_installation"]  do
     result = ShellCmd.run_testsuite("setup")
     result[:status].success?.should be_true
     (/Dependency installation complete/ =~ result[:output]).should_not be_nil
@@ -28,7 +28,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags:["cnf_installation"] do
+  it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags: ["cnf_installation"] do
     result = ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
   ensure
@@ -36,7 +36,7 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-config arg as an alias for cnf-path", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-config arg as an alias for cnf-path", tags: ["cnf_installation"] do
     result = ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
   ensure
@@ -44,7 +44,7 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=example-cnfs/coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -54,7 +54,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should fail on incorrect config", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should fail on incorrect config", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-bad-config.yml", expect_failure: true)
       (/Error during parsing CNF config/ =~ result[:output]).should_not be_nil
@@ -63,7 +63,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with a cnf-testsuite.yml", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with a cnf-testsuite.yml", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-config=example-cnfs/coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -73,7 +73,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should work with cnf-testsuite.yml that has no directory associated with it", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should work with cnf-testsuite.yml that has no directory associated with it", tags: ["cnf_installation"] do
     begin
       #TODO force cnfs/<name> to be deployment name and not the directory name
       result = ShellCmd.cnf_install("cnf-config=spec/fixtures/cnf-testsuite.yml verbose")
@@ -84,7 +84,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with helm_directory that descends multiple directories", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with helm_directory that descends multiple directories", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/multi_helm_directories/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -94,7 +94,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should properly install/uninstall old versions of cnf configs", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should properly install/uninstall old versions of cnf configs", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite-v1-example.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -104,7 +104,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should fail if another CNF is already installed", tags:["cnf_installation"] do
+  it "'cnf_install' should fail if another CNF is already installed", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -116,7 +116,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_multiple_deployments/cnf-testsuite.yml")
       (/All "coredns" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -132,7 +132,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall deployment with mixed installation methods", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall deployment with mixed installation methods", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nginx-redis/cnf-testsuite.yml")
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -146,7 +146,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should handle partial deployment failures gracefully", tags:["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should handle partial deployment failures gracefully", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-partial-deployment-failure/cnf-testsuite.yml", expect_failure: true)
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -157,7 +157,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should detect and report conflicts between deployments", tags:["cnf_installation"] do
+  it "'cnf_install' should detect and report conflicts between deployments", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-conflicting-deployments.yml", expect_failure: true)
       (/Deployment names should be unique/ =~ result[:output]).should_not be_nil
@@ -166,7 +166,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should correctly handle deployment priority", tags:["cnf_installation"] do
+  it "'cnf_install' should correctly handle deployment priority", tags: ["cnf_installation"] do
     # (kosstennbl) ELK stack requires to be installed with specific order, otherwise it would give errors
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-elk-stack/cnf-testsuite.yml timeout=600")


### PR DESCRIPTION
## Description
GH actions tag discovery command (`grep -roP --no-filename 'tags: \K(\[|")(.*)(\]|")' spec/ | tr -d '[],' | tr -s '\n' ' ' | xargs -n1 | sort -u | xargs | sed s/:/_/g`) requires that there is a space between colon and the left bracket. This has gone unnoticed in the #2184 pull request and it is the only pull request that went unchecked (other existing pull requests will likely need to be rebased), since it did not change any functionality but merely renamed some tasks, this should not be a problem.

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update