### PR TITLE
Fix: Repair `uninstall_all`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -239,6 +239,7 @@ Run the following to uninstall the CNF (this is assuming you installed the cnf-t
 ```
 cnf-testsuite cnf_uninstall
 ```
-You can also run `cleanup` and cnf-testsuite will attempt to cleanup everything.
+
+To also uninstall helper tools deployed by testsuite run `uninstall_all`.
 
 _NOTE: CNF uninstallation does not handle manually deployed CNFs_

--- a/SOURCE_INSTALL.md
+++ b/SOURCE_INSTALL.md
@@ -261,7 +261,7 @@ Run the following to uninstall the CNF:
 ./cnf-testsuite cnf_uninstall
 ```
 
-You can also run `cleanup` and cnf-testsuite will attempt to cleanup everything.
+To also uninstall helper tools deployed by testsuite run `uninstall_all`.
 
 _NOTE: CNF uninstallation does not handle manually deployed CNFs_
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -120,7 +120,7 @@ cnf-config=<path_to_your_config_file>/cnf-testsuite.yml
 #### Clean up the CNTI Test Catalog, the K8s cluster, and upstream projects:
 
 ```
-./cnf-testsuite cleanup
+./cnf-testsuite uninstall_all
 ```
 
 ---

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -17,6 +17,17 @@ describe "Installation" do
     (/Dependency installation complete/ =~ result[:output]).should_not be_nil
   end
 
+  it "'uninstall_all' should uninstall CNF and testsuite dependencies", tags: ["cnf_installation"] do
+    begin
+      result = ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-minimal-cnf/")
+      (/CNF installation complete/ =~ result[:output]).should_not be_nil
+    ensure
+      result = ShellCmd.run_testsuite("uninstall_all")
+      (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
+      (/Testsuite helper tools uninstalled./ =~ result[:output]).should_not be_nil
+    end
+  end
+
   it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags:["cnf_installation"] do
     result = ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -48,7 +59,7 @@ describe "Installation" do
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-bad-config.yml", expect_failure: true)
       (/Error during parsing CNF config/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall(expect_failure: true)
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -98,7 +109,7 @@ describe "Installation" do
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml")
-      (/A CNF is already set up. Setting up multiple CNFs is not allowed./ =~ result[:output]).should_not be_nil
+      (/A CNF is already installed. Installation of multiple CNFs is not allowed./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
       (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
@@ -151,7 +162,7 @@ describe "Installation" do
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-conflicting-deployments.yml", expect_failure: true)
       (/Deployment names should be unique/ =~ result[:output]).should_not be_nil
     ensure
-      ShellCmd.cnf_uninstall(expect_failure: true)
+      ShellCmd.cnf_uninstall()
     end
   end
 
@@ -206,5 +217,12 @@ describe "Installation" do
         pair[1].should be > pair[0]
       end
     end
-  end  
+  end
+
+  it "'cnf_uninstall' should warn user if no CNF is found", tags: ["cnf_installation"] do
+    begin
+      result = ShellCmd.cnf_uninstall()
+      (/CNF uninstallation skipped/ =~ result[:output]).should_not be_nil
+    end
+  end
 end

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -7,8 +7,14 @@ desc "Alias for cnf_uninstall"
 task "uninstall", ["cnf_uninstall"] do  |_, args|
 end
 
+# Private task
+task "_tools_uninstall_start" do
+  stdout_success "Uninstalling testsuite helper tools."
+end
+
 desc "Cleans up the CNF Test Suite helper tools and containers"
 task "tools_uninstall", [
+    "_tools_uninstall_start",
     "uninstall_sonobuoy",
     "uninstall_chaosmesh",
     "uninstall_litmus",
@@ -20,11 +26,12 @@ task "tools_uninstall", [
     # Helm needs to be uninstalled last to allow other uninstalls to use helm if necessary.
     # Check this issue for details - https://github.com/cncf/cnf-testsuite/issues/1586
     "uninstall_local_helm"
-  ] do  |_, args|
+  ] do |_, args|
+  stdout_success "Testsuite helper tools uninstalled."
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"
-task "uninstall_all", ["cnf_uninstall", "tools_uninstall"] do  |_, args|
+task "uninstall_all", ["cnf_uninstall", "tools_uninstall"] do |_, args|
 end
 
 task "delete_results" do |_, args|

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -131,8 +131,8 @@ module CNFInstall
   def self.uninstall_cnf()
     cnf_config_path = File.join(CNF_DIR, CONFIG_FILE)
     if !File.exists?(cnf_config_path)
-      stdout_failure "No CNF config found in #{CNF_DIR} directory. Nothing to uninstall"
-      exit 1
+      stdout_warning "CNF uninstallation skipped. No CNF config found in #{CNF_DIR} directory. "
+      return
     end
     config = Config.parse_cnf_config_from_file(cnf_config_path)
 


### PR DESCRIPTION
## Description
As of release v1.4.0 the `uninstall_all` task is broken and some testsuite dependencies cannot be uninstalled the intended way (cluster tools, etc.). This has been caused by the `CNFInstall.uninstall_cnf` function that was exiting with code 1 in case no CNF was installed, to fix this we have decided to relegate it to a warning (this makes the change significantly easier) and removed the `exit 1` command.

To avoid a similar situation in future, two spec tests have been added. The `uninstall_all` spec test required a change to `tools_uninstall` task since it previously gave no indication of passing. Further verification of `tools_uninstall` passing correctly should be added, but it might be out of the scope of this ticket.

Additionally some renaming regarding cleanup/uninstall has been left undone after #2184, this has been remediated as part of this ticket.

## Issues:
Refs: #2209

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
