### PR TITLE
Fix: helm_chart_valid did not consider value files passed through helm_values

### DIFF
--- a/sample-cnfs/sample_conditional_values_file/chart/Chart.yaml
+++ b/sample-cnfs/sample_conditional_values_file/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nginx
+description: A simple chart that requires "-f test-values.yaml" to be passed
+type: application
+version: 0.1.0
+appVersion: 1.0.0

--- a/sample-cnfs/sample_conditional_values_file/chart/templates/deployment.yaml
+++ b/sample-cnfs/sample_conditional_values_file/chart/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount | required "Error: replicaCount is a required value and must be specified" }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: nginx:1.19
+        ports:
+        - containerPort: 80

--- a/sample-cnfs/sample_conditional_values_file/chart/values.schema.json
+++ b/sample-cnfs/sample_conditional_values_file/chart/values.schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+      "replicaCount": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Number of replicas for the Deployment."
+      }
+    },
+    "required": ["replicaCount"]
+  }
+  

--- a/sample-cnfs/sample_conditional_values_file/chart/values.yaml
+++ b/sample-cnfs/sample_conditional_values_file/chart/values.yaml
@@ -1,0 +1,1 @@
+# Default values, replicaCount is intentionally missing to force reliance on an override file.

--- a/sample-cnfs/sample_conditional_values_file/cnf-testsuite.yml
+++ b/sample-cnfs/sample_conditional_values_file/cnf-testsuite.yml
@@ -1,0 +1,8 @@
+---
+config_version: v2
+deployments:
+  helm_dirs:
+  - name: nginx
+    helm_directory: chart
+    namespace: cnfspace
+    helm_values: "-f ./sample-cnfs/sample_conditional_values_file/test-values.yaml"

--- a/sample-cnfs/sample_conditional_values_file/test-values.yaml
+++ b/sample-cnfs/sample_conditional_values_file/test-values.yaml
@@ -1,0 +1,2 @@
+# Additional values.yaml to ensure linting passes
+replicaCount: 1

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -31,6 +31,15 @@ describe CnfTestSuite do
     result = ShellCmd.cnf_uninstall("verbose")
   end
 
+  it "'helm_chart_valid' should pass on a good helm chart with additional values file", tags: ["helm"]  do
+    ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_conditional_values_file/cnf-testsuite.yml verbose")
+    result = ShellCmd.run_testsuite("helm_chart_valid verbose")
+    result[:status].success?.should be_true
+    (/Helm chart lint passed on all charts/ =~ result[:output]).should_not be_nil
+  ensure
+    result = ShellCmd.cnf_uninstall("verbose")
+  end
+
   it "'helm_chart_valid' should fail on a bad helm chart", tags: ["helm"] do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml verbose skip_wait_for_install", expect_failure: true)


### PR DESCRIPTION
## Description
Makes the underlying `helm lint` command, ran in the `helm_chart_valid` task, also verify if any override value files should be utilized. Also adds a spec test to make sure that this functions correctly. The `values.schema.json` file guarantees that without `-f test-values.yaml`, `helm lint` would not pass.

## Issues:
Refs: #2206

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
