### PR TITLE
Fix Jenkins CNF installation in CI

### DIFF
--- a/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
+++ b/sample-cnfs/sample_good_signal_handling_tini/cnf-testsuite.yml
@@ -4,6 +4,7 @@ deployments:
   helm_charts:
   - name: jenkins
     helm_chart_name: jenkins
-    helm_values: --set controller.sidecars.configAutoReload.enabled=false
+    helm_values: --set controller.sidecars.configAutoReload.enabled=false --set controller.installPlugins=false
     helm_repo_name: jenkins
     helm_repo_url: https://charts.jenkins.io
+


### PR DESCRIPTION
Failure was internal Jenkins dependency installation in init-container. Add 'installPlugins=false' helm value to not install unneeded dependencies to avoid similar problems in the future and speed up Jenkins deployment.

## Description
(name of issue/change)

## Issues:
Refs: #NNN

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
